### PR TITLE
#5 hotfix: globalexceptionhandler 처리 못하는 이슈 해결 

### DIFF
--- a/user-service/src/main/java/com/pda/user_service/UserServiceApplication.java
+++ b/user-service/src/main/java/com/pda/user_service/UserServiceApplication.java
@@ -3,7 +3,7 @@ package com.pda.user_service;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = "com.pda")
 public class UserServiceApplication {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- user-service 모듈 어플리케이션에 `@SpringBootApplication(scanBasePackages = "com.pda")`을 추가해주었습니다.

<br/>

## 🔥 트러블 슈팅 (선택) 
- user-service 모듈에서 예외 시 utils 모듈 내의 globalexceptionhandler가 처리하지 못하는 문제가 발생하였습니다.
globalexceptionhandler의 생성자 내에서 로그를 찍어보니 찍히지 않았습니다. 
user-service 모듈 어플리케이션 실행 시 utils 모듈은 외부 모듈이기에 스캔을 하지 않는다는 점을 알게 되었습니다. 
SpringBootApplication 어노테이션에서 scanBasePackages을 지정해주어 이를 해결하였습니다. 

<br/>

## 🌱 관련 이슈 (필수)
- (관련 이슈 번호를 작성해주세요) 
- close #5 

<br/> 

## 📚 기타 (선택) 
- 민우님 서히 감사합니다 ~~!!!

<br/>
