### PR TITLE
fix: Security 인가 설정 변경 & jwt 토큰 읽기 

### DIFF
--- a/user-service/src/main/java/com/pda/investment_test/controller/InvestmentTestController.java
+++ b/user-service/src/main/java/com/pda/investment_test/controller/InvestmentTestController.java
@@ -1,0 +1,16 @@
+package com.pda.investment_test.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+@RequestMapping("/api/investment_tests")
+public class InvestmentTestController {
+    @GetMapping("/")
+    public String test() {
+        return "test";
+    }
+}

--- a/user-service/src/main/java/com/pda/security/JwtAuthenticationFilter.java
+++ b/user-service/src/main/java/com/pda/security/JwtAuthenticationFilter.java
@@ -5,12 +5,14 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.GenericFilterBean;
 
 import java.io.IOException;
 
+@Slf4j
 public class JwtAuthenticationFilter extends GenericFilterBean {
 
     JwtTokenProvider jwtTokenProvider;
@@ -25,6 +27,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
 
         if(token != null) {
             Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            log.info(authentication.toString());
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 

--- a/user-service/src/main/java/com/pda/security/JwtTokenProvider.java
+++ b/user-service/src/main/java/com/pda/security/JwtTokenProvider.java
@@ -16,6 +16,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.util.StringUtils;
 
 import java.security.Key;
 import java.util.Base64;
@@ -65,13 +66,18 @@ public class JwtTokenProvider {
 
     // 헤더에서 토큰 얻기
     public String resolveToken(HttpServletRequest request) {
-        return request.getHeader("Authorization");
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
     }
 
 
     // 내가 만든 토큰인지 & username 기반으로 DB 에서 객체 가져오기
     public Authentication getAuthentication(String token) {
         UserDetails userDetails = userDetailsService.loadUserByUsername(getUsername(token));
+        log.info("auth - " + userDetails.getUsername());
         return new UsernamePasswordAuthenticationToken(userDetails, "",
                 userDetails.getAuthorities());
     }

--- a/user-service/src/main/java/com/pda/security/WebSecurityConfig.java
+++ b/user-service/src/main/java/com/pda/security/WebSecurityConfig.java
@@ -39,11 +39,10 @@ public class WebSecurityConfig {
         http
                 .csrf((csrfConfig) -> csrfConfig.disable() // .csrf().disable()
                 )
-                .authorizeHttpRequests((authorizeRequest ->
-                        authorizeRequest.requestMatchers("/").authenticated() // .anyRequest().authenticated()
-                                .requestMatchers( "/api/users/signup", "api/users/login", "api/users/login/kakao").permitAll() //.antMatchers("/", "/home", "/join", "/login").permitAll()  // antMatchers : 여기는 인증안된 사람도 갈 수 있음
-
-                ))
+                .authorizeHttpRequests(authorizeRequests -> authorizeRequests
+                        .requestMatchers("/error", "/api/users/signup", "/api/users/login", "/api/users/login/kakao").permitAll()
+                        .anyRequest().authenticated()
+                )
                 .formLogin((formLogin) -> formLogin.disable()) // formLogin.disable()
                 .logout((logoutConfig) -> logoutConfig.permitAll()) //  .logout().permitAll()// 로그아웃 아무나 못하게
                 // 사용할 필터와 시기 지정해주기

--- a/user-service/src/main/java/com/pda/user_service/service/UserService.java
+++ b/user-service/src/main/java/com/pda/user_service/service/UserService.java
@@ -17,6 +17,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -27,7 +30,7 @@ import java.util.Optional;
 @Slf4j
 @Service
 @PropertySource(value = {"env.properties"})
-public class UserService {
+public class UserService implements UserDetailsService {
     @Autowired
     private UserRepository userRepository;
     @Autowired
@@ -118,5 +121,11 @@ public class UserService {
         else {
             throw new NotCorrectPasswordException("비밀번호가 일치하지 않습니다.");
         }
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Optional<User> user = userRepository.findById(Integer.valueOf(username));
+        return user.orElseThrow();
     }
 }


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- Security 인가 설정 변경 
  - 모든 경로에 인증된 사용자만 접근 가능하도록 설정
  - "/error", "/api/users/signup", "/api/users/login", "/api/users/login/kakao"는 모든 사용자에게 허용하도록 설정
-  jwt 토큰 읽기 : Bearer ~ 로 시작하는 토큰을 읽어 로그로 출력

<br/>

## 🌱 관련 이슈 (필수)
- (관련 이슈 번호를 작성해주세요) 
- #1

<br/> 
