### PR TITLE
#33 feat: 포트폴리오 수익률 연산 구현

### DIFF
--- a/portfolio-service/src/main/java/com/pda/portfolio_service/dto/HititPortfoliosFundsResponseDto.java
+++ b/portfolio-service/src/main/java/com/pda/portfolio_service/dto/HititPortfoliosFundsResponseDto.java
@@ -6,11 +6,11 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class HititPortfoliosFundsResponseDto {
-    private String fund_code;
-    private Integer portfolio_id;
-    private String fund_name;
-    private String fund_type_detail;
-    private String company_name;
+    private String fundCode;
+    private Integer portfolioId;
+    private String fundName;
+    private String fundTypeDetail;
+    private String companyName;
     private Float weight;
     private Float return3m;
 }

--- a/portfolio-service/src/main/java/com/pda/portfolio_service/dto/HititPortfoliosResponseDto.java
+++ b/portfolio-service/src/main/java/com/pda/portfolio_service/dto/HititPortfoliosResponseDto.java
@@ -12,5 +12,6 @@ public class HititPortfoliosResponseDto {
     private String summary;
     private Integer minimumSubscriptionFee;
     private Integer stockExposure;
+    private Float return3m;
 }
 

--- a/portfolio-service/src/main/java/com/pda/portfolio_service/service/PortfolioService.java
+++ b/portfolio-service/src/main/java/com/pda/portfolio_service/service/PortfolioService.java
@@ -14,6 +14,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.Comparator;
 
 @Slf4j
 @Service
@@ -65,6 +66,7 @@ public class PortfolioService {
                         portfolioFund.getCompanyName(),
                         portfolioFund.getWeight(),
                         portfolioFund.getReturn3m()))
+                .sorted(Comparator.comparingDouble(HititPortfoliosFundsResponseDto::getWeight).reversed())
                 .collect(Collectors.toList());
     }
 }

--- a/portfolio-service/src/main/java/com/pda/portfolio_service/service/PortfolioService.java
+++ b/portfolio-service/src/main/java/com/pda/portfolio_service/service/PortfolioService.java
@@ -66,7 +66,8 @@ public class PortfolioService {
                         portfolioFund.getCompanyName(),
                         portfolioFund.getWeight(),
                         portfolioFund.getReturn3m()))
-                .sorted(Comparator.comparingDouble(HititPortfoliosFundsResponseDto::getWeight).reversed())
+                .sorted(Comparator.comparingDouble(HititPortfoliosFundsResponseDto::getWeight).reversed()
+                        .thenComparing(HititPortfoliosFundsResponseDto::getFundName, Comparator.nullsLast(Comparator.naturalOrder())))
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 📌 작업 내용 (필수)
 - DataBase 수정
   - private_portfolios_fund_products 테이블에 return_3m 데이터 모두 추가
 - 포트폴리오 수익률 연산 기능
   - PortfolioService의 getHititPortfolios 메서드에 수익률 연산 로직 추가
   - HititPortfoliosResponseDto에 return_3m 컬럼에 대응할 return3m 필드 추가
 - 포트폴리오 상세 펀드 FE로 반환시 weight 값으로 오름차순 정렬하여 반환
 - 포트폴리오 상세 펀드 FE로 반환시 weight 값으로 오름차순 시 동일한 비중일 경우 fundName 값으로 문자열 정렬 후 반환
 - HititPortfoliosFundsResponseDto 필드명 snake_case -> camelCase로 수정

<br/>

## 🌱 관련 이슈 (필수)
- (관련 이슈 번호를 작성해주세요) 
- close #33

<br/> 
