### PR TITLE
feat: 마이데이터 은행 연동 기능 추가 

### DIFF
--- a/asset-service/build.gradle
+++ b/asset-service/build.gradle
@@ -1,0 +1,15 @@
+ext {
+    set('springBootVersion', '3.2.6')
+    set('springCloudVersion', '2023.0.0')
+}
+
+dependencies {
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.boot:spring-boot-dependencies:${springBootVersion}"
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}

--- a/asset-service/src/main/java/com/pda/asset_service/AssetServiceApplication.java
+++ b/asset-service/src/main/java/com/pda/asset_service/AssetServiceApplication.java
@@ -2,8 +2,12 @@ package com.pda.asset_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
+@EnableFeignClients
 @SpringBootApplication(scanBasePackages = "com.pda")
+@EnableJpaRepositories(basePackages = {"com.pda.asset_service"})
 public class AssetServiceApplication {
 
 	public static void main(String[] args) {

--- a/asset-service/src/main/java/com/pda/asset_service/controller/AssetController.java
+++ b/asset-service/src/main/java/com/pda/asset_service/controller/AssetController.java
@@ -1,0 +1,28 @@
+package com.pda.asset_service.controller;
+
+import com.pda.asset_service.dto.MydataInfoDto;
+import com.pda.asset_service.dto.UserAccountInfoDto;
+import com.pda.asset_service.service.AssetServiceImpl;
+import com.pda.utils.api_utils.ApiUtils;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@Slf4j
+@RequestMapping("/api/assets")
+@AllArgsConstructor
+public class AssetController {
+
+    private final AssetServiceImpl assetService;
+
+    @PostMapping("/mydata-link")
+    public ApiUtils.ApiResult<List<MydataInfoDto>> linkMydata(@RequestBody UserAccountInfoDto userAccountInfoDto){
+
+        List<MydataInfoDto> bankAccountsLinkInfo = assetService.mydataLink(userAccountInfoDto);
+
+        return ApiUtils.success(bankAccountsLinkInfo);
+    }
+}

--- a/asset-service/src/main/java/com/pda/asset_service/dto/BankAccountDto.java
+++ b/asset-service/src/main/java/com/pda/asset_service/dto/BankAccountDto.java
@@ -1,0 +1,35 @@
+package com.pda.asset_service.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BankAccountDto {
+    @JsonProperty("account_no")
+    private String accountNo;
+
+    @JsonProperty("bank_name")
+    private String bankName;
+
+    @JsonProperty("account_type")
+    private String accountType;
+
+    private String name;
+
+    private int balance;
+
+    @JsonProperty("created_at")
+    private Date createdAt;
+
+    @JsonProperty("user_id")
+    private int userId;
+}

--- a/asset-service/src/main/java/com/pda/asset_service/dto/BankAccountResponseDto.java
+++ b/asset-service/src/main/java/com/pda/asset_service/dto/BankAccountResponseDto.java
@@ -1,0 +1,30 @@
+package com.pda.asset_service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BankAccountResponseDto {
+
+    private String accountNo;
+
+    private String bankName;
+
+    private String accountType;
+
+    private String name;
+
+    private int balance;
+
+    private Date createdAt;
+
+    private int userId;
+}

--- a/asset-service/src/main/java/com/pda/asset_service/dto/MydataInfoDto.java
+++ b/asset-service/src/main/java/com/pda/asset_service/dto/MydataInfoDto.java
@@ -1,0 +1,20 @@
+package com.pda.asset_service.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MydataInfoDto {
+    private int id;
+    private String assetType;
+    private String companyName;
+    private String accountType;
+    private String accountNo;
+}

--- a/asset-service/src/main/java/com/pda/asset_service/dto/UserAccountInfoDto.java
+++ b/asset-service/src/main/java/com/pda/asset_service/dto/UserAccountInfoDto.java
@@ -1,0 +1,17 @@
+package com.pda.asset_service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.pda.asset_service.jpa.BankAccount;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class UserAccountInfoDto {
+    @JsonProperty("user_id")
+    private int userId;
+    @JsonProperty("bank_accounts")
+    private List<String> bankAccounts;
+
+
+}

--- a/asset-service/src/main/java/com/pda/asset_service/feign/MydataServiceClient.java
+++ b/asset-service/src/main/java/com/pda/asset_service/feign/MydataServiceClient.java
@@ -1,0 +1,20 @@
+package com.pda.asset_service.feign;
+
+import com.pda.asset_service.dto.BankAccountDto;
+import com.pda.asset_service.dto.BankAccountResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+import java.util.Optional;
+
+@FeignClient(name = "mydata-service", url = "http://localhost:8082")
+public interface MydataServiceClient {
+
+    @GetMapping("/api/mydata/bank-account/{userId}")
+    List<BankAccountDto> getAllBankAccountData(@PathVariable("userId") int userId);
+    @GetMapping("/api/mydata/bank-account/{userId}/{bankName}")
+    Optional<List<BankAccountResponseDto>> getBankAccountsByUserIdAndBankName(@PathVariable("userId") int userId, @PathVariable("bankName") String bankName);
+
+}

--- a/asset-service/src/main/java/com/pda/asset_service/jpa/AssetUser.java
+++ b/asset-service/src/main/java/com/pda/asset_service/jpa/AssetUser.java
@@ -1,0 +1,20 @@
+package com.pda.asset_service.jpa;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "users")
+public class AssetUser {
+
+    @Id
+    private int id;
+
+}

--- a/asset-service/src/main/java/com/pda/asset_service/jpa/AssetUserRepository.java
+++ b/asset-service/src/main/java/com/pda/asset_service/jpa/AssetUserRepository.java
@@ -1,0 +1,6 @@
+package com.pda.asset_service.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AssetUserRepository extends JpaRepository<AssetUser, Integer> {
+}

--- a/asset-service/src/main/java/com/pda/asset_service/jpa/BankAccount.java
+++ b/asset-service/src/main/java/com/pda/asset_service/jpa/BankAccount.java
@@ -1,0 +1,41 @@
+package com.pda.asset_service.jpa;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "bank_accounts")
+//@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class BankAccount {
+
+    @Id
+    @Column(name = "account_no")
+    private String accountNo;
+
+    @Column(name ="bank_name")
+    private String bankName;
+
+    @Column(name ="account_type")
+    private String accountType;
+
+    private String name;
+
+    private int balance;
+
+    @Column(name ="created_at")
+    private Date createdAt;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private AssetUser assetUser;
+}

--- a/asset-service/src/main/java/com/pda/asset_service/jpa/BankAccountRepository.java
+++ b/asset-service/src/main/java/com/pda/asset_service/jpa/BankAccountRepository.java
@@ -1,0 +1,12 @@
+package com.pda.asset_service.jpa;
+
+
+import lombok.AllArgsConstructor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface BankAccountRepository extends JpaRepository<BankAccount, String> {
+
+}

--- a/asset-service/src/main/java/com/pda/asset_service/jpa/MydataInfo.java
+++ b/asset-service/src/main/java/com/pda/asset_service/jpa/MydataInfo.java
@@ -1,0 +1,32 @@
+package com.pda.asset_service.jpa;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "mydata_info")
+public class MydataInfo {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Column(name = "asset_type")
+    private String assetType;
+
+    @Column(name = "company_name")
+    private String companyName;
+
+    @Column(name = "account_type")
+    private String accountType;
+
+    @Column(name = "account_no")
+    private String accountNo;
+}

--- a/asset-service/src/main/java/com/pda/asset_service/jpa/MydataInfoRepository.java
+++ b/asset-service/src/main/java/com/pda/asset_service/jpa/MydataInfoRepository.java
@@ -1,0 +1,8 @@
+package com.pda.asset_service.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MydataInfoRepository extends JpaRepository<MydataInfo, Integer> {
+
+    MydataInfo findByAccountNo(String accountNo);
+}

--- a/asset-service/src/main/java/com/pda/asset_service/service/AssetService.java
+++ b/asset-service/src/main/java/com/pda/asset_service/service/AssetService.java
@@ -1,0 +1,12 @@
+package com.pda.asset_service.service;
+
+import com.pda.asset_service.dto.MydataInfoDto;
+import com.pda.asset_service.dto.UserAccountInfoDto;
+
+
+import java.util.List;
+
+public interface AssetService {
+    List<MydataInfoDto> mydataLink(UserAccountInfoDto userAccountInfoDto);
+
+}

--- a/asset-service/src/main/java/com/pda/asset_service/service/AssetServiceImpl.java
+++ b/asset-service/src/main/java/com/pda/asset_service/service/AssetServiceImpl.java
@@ -1,0 +1,46 @@
+package com.pda.asset_service.service;
+
+import com.pda.asset_service.dto.BankAccountDto;
+import com.pda.asset_service.dto.MydataInfoDto;
+import com.pda.asset_service.dto.UserAccountInfoDto;
+import com.pda.asset_service.feign.MydataServiceClient;
+import com.pda.asset_service.jpa.BankAccountRepository;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+@Slf4j
+public class AssetServiceImpl implements AssetService{
+
+    private final BankAccountRepository bankAccountRepository;
+    private final MydataServiceClient mydataServiceClient;
+
+    private final BankAccountServiceImpl bankAccountService;
+    private final CardServiceImpl cardService;
+    private final SecurityTransactionServiceImpl securityTransactionService;
+
+    @Override
+    public List<MydataInfoDto> mydataLink(UserAccountInfoDto userAccountInfoDto) {
+
+
+        // controller에 { "userId": 1,"bankAccounts": ["국민은행", "신한은행"],"securityAccounts": ["신한투자증권"]} 형식으로 요청 온다
+        // service에서는 각 기관을 돌면서 데이터 있는 지 확인
+        // 있으면 mydataInfo에 있다고 저장
+        // responseDto에 담아줌....
+
+        int userId = userAccountInfoDto.getUserId();
+        log.info("userId = {}", userId);
+
+        List<MydataInfoDto> bankAccountsLinkInfo = bankAccountService.mydataLink(userId,  userAccountInfoDto.getBankAccounts());
+        log.info("bankAccountsLinkInfo = {}", bankAccountsLinkInfo);
+
+
+
+        return bankAccountsLinkInfo;
+    }
+
+}

--- a/asset-service/src/main/java/com/pda/asset_service/service/BankAccountService.java
+++ b/asset-service/src/main/java/com/pda/asset_service/service/BankAccountService.java
@@ -1,0 +1,17 @@
+package com.pda.asset_service.service;
+
+import com.pda.asset_service.dto.BankAccountDto;
+import com.pda.asset_service.dto.BankAccountResponseDto;
+import com.pda.asset_service.dto.MydataInfoDto;
+import com.pda.asset_service.jpa.BankAccount;
+
+import java.util.List;
+
+public interface BankAccountService {
+
+    BankAccount convertToEntity(BankAccountResponseDto bankAccountDto);
+
+    BankAccountDto convertToDto(BankAccount bankAccount);
+
+    List<MydataInfoDto> mydataLink(int userId, List<String> bankAccounts);
+}

--- a/asset-service/src/main/java/com/pda/asset_service/service/BankAccountServiceImpl.java
+++ b/asset-service/src/main/java/com/pda/asset_service/service/BankAccountServiceImpl.java
@@ -1,0 +1,98 @@
+package com.pda.asset_service.service;
+
+import com.pda.asset_service.dto.BankAccountDto;
+import com.pda.asset_service.dto.BankAccountResponseDto;
+import com.pda.asset_service.dto.MydataInfoDto;
+import com.pda.asset_service.feign.MydataServiceClient;
+import com.pda.asset_service.jpa.*;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@AllArgsConstructor
+@Slf4j
+public class BankAccountServiceImpl implements BankAccountService{
+
+    private final AssetUserRepository assetUserRepository;
+    private final BankAccountRepository bankAccountRepository;
+    private final MydataInfoRepository mydataInfoRepository;
+    private final MydataServiceClient mydataServiceClient;
+
+    @Override
+    public BankAccount convertToEntity(BankAccountResponseDto bankAccountDto) {
+        log.info("BankAccountServiceImpl User Id = {}", bankAccountDto.getUserId());
+        AssetUser user = assetUserRepository.findById(bankAccountDto.getUserId()).orElseThrow();
+        return BankAccount.builder()
+                .accountNo(bankAccountDto.getAccountNo())
+                .bankName(bankAccountDto.getBankName())
+                .accountType(bankAccountDto.getAccountType())
+                .name(bankAccountDto.getName())
+                .balance(bankAccountDto.getBalance())
+                .createdAt(bankAccountDto.getCreatedAt())
+                .assetUser(user)
+                .build();
+    }
+
+    @Override
+    public BankAccountDto convertToDto(BankAccount bankAccount) {
+        log.info("convertToDto합니다 = {}", bankAccount);
+        return BankAccountDto.builder()
+                .accountNo(bankAccount.getAccountNo())
+                .bankName(bankAccount.getBankName())
+                .accountType(bankAccount.getAccountType())
+                .name(bankAccount.getName())
+                .balance(bankAccount.getBalance())
+                .createdAt(bankAccount.getCreatedAt())
+                .userId(bankAccount.getAssetUser().getId())
+                .build();
+    }
+
+    @Override
+    public List<MydataInfoDto> mydataLink(int userId, List<String> bankAccounts) {
+
+        List<MydataInfoDto> bankAccountsLinkInfo = new ArrayList<>();
+
+        // 은행 계좌 정보 처리
+        for (String bankName : bankAccounts) {
+            log.info("userAccount = {}", bankName);
+            // 하나의 은행에 여러 계좌가 있으면 리스트로 여러 개가 온다..
+            Optional<List<BankAccountResponseDto>> bankAccountsResponse = mydataServiceClient.getBankAccountsByUserIdAndBankName(userId, bankName);
+            log.info("bankAccounts Response From Mydata-service = {}", bankAccountsResponse);
+            if (bankAccountsResponse.isPresent()) {
+                log.info("==========================================================================");
+                for (BankAccountResponseDto bankAccountDto : bankAccountsResponse.get()) {
+                    log.info("bank account convert Entity = {}", bankAccountDto);
+                    BankAccount bankAccount = convertToEntity(bankAccountDto);
+                    log.info("========================== = {}", bankAccount);
+                    bankAccountRepository.save(bankAccount);
+                    log.info("bank account Saved = {}", bankAccount);
+
+                    mydataInfoRepository.save(MydataInfo.builder()
+                            .assetType("bank_accounts")
+                            .companyName(bankAccount.getBankName())
+                            .accountType(bankAccount.getAccountType())
+                            .accountNo(bankAccount.getAccountNo())
+                            .build());
+
+                    MydataInfo SavedInfo = mydataInfoRepository.findByAccountNo(bankAccount.getAccountNo());
+                    MydataInfoDto mydataInfoDto = MydataInfoDto.builder()
+                            .assetType(SavedInfo.getAssetType())
+                            .companyName(SavedInfo.getCompanyName())
+                            .accountType(SavedInfo.getAccountType())
+                            .accountNo(bankAccount.getAccountNo())
+                            .build();
+
+                    bankAccountsLinkInfo.add(mydataInfoDto);
+                }
+            }
+
+        }
+        return bankAccountsLinkInfo;
+
+    }
+}

--- a/asset-service/src/main/java/com/pda/asset_service/service/MydataInfoService.java
+++ b/asset-service/src/main/java/com/pda/asset_service/service/MydataInfoService.java
@@ -1,0 +1,5 @@
+package com.pda.asset_service.service;
+
+
+public interface MydataInfoService {
+}

--- a/asset-service/src/main/java/com/pda/asset_service/service/MydataServiceImpl.java
+++ b/asset-service/src/main/java/com/pda/asset_service/service/MydataServiceImpl.java
@@ -1,0 +1,14 @@
+package com.pda.asset_service.service;
+
+import com.pda.asset_service.jpa.MydataInfoRepository;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+@Slf4j
+public class MydataServiceImpl implements MydataInfoService{
+
+    private final MydataInfoRepository mydataInfoRepository;
+}

--- a/mydata-service/src/main/java/com/pda/mydata_service/MydataServiceApplication.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/MydataServiceApplication.java
@@ -2,8 +2,10 @@ package com.pda.mydata_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication(scanBasePackages = "com.pda")
+@EnableJpaRepositories(basePackages = {"com.pda.mydata_service"})
 public class MydataServiceApplication {
 
 	public static void main(String[] args) {

--- a/mydata-service/src/main/java/com/pda/mydata_service/controller/MydataController.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/controller/MydataController.java
@@ -1,0 +1,41 @@
+package com.pda.mydata_service.controller;
+
+import com.pda.mydata_service.dto.BankAccountDto;
+import com.pda.mydata_service.service.BankAccountServiceImpl;
+import com.pda.mydata_service.service.MydataServiceImpl;
+import com.pda.utils.api_utils.ApiUtils;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@Slf4j
+@RequestMapping("/api/mydata")
+@AllArgsConstructor
+public class MydataController {
+
+    private final MydataServiceImpl mydataService;
+    private final BankAccountServiceImpl bankAccountService;
+
+//    @GetMapping("/bank-account/")
+//    public ApiUtils.ApiResult<Optional<List<BankAccountDto>>> getBankAccountData(@RequestParam int userId ){
+//        return ApiUtils.success(mydataService.getAllBankAccounts(userId));
+//    }
+    @GetMapping("/bank-account/{userId}/{bankName}")
+    public Optional<List<BankAccountDto>> getBankAccountsByUserIdAndBankName(
+            @PathVariable("userId") int userId,
+            @PathVariable("bankName") String bankName) {
+
+        log.info("mydata controller");
+
+        Optional<List<BankAccountDto>> bankAccounts = mydataService.getBankAccountsByUserIdAndBankName(userId, bankName);
+        log.info("mydata controller result = {}", bankAccounts);
+        return bankAccounts;
+    }
+}

--- a/mydata-service/src/main/java/com/pda/mydata_service/dto/BankAccountDto.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/dto/BankAccountDto.java
@@ -1,0 +1,35 @@
+package com.pda.mydata_service.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Data
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class BankAccountDto {
+//    @JsonProperty("account_no")
+    private String accountNo;
+
+//    @JsonProperty("bank_name")
+    private String bankName;
+
+//    @JsonProperty("account_type")
+    private String accountType;
+
+    private String name;
+
+    private int balance;
+
+//    @JsonProperty("created_at")
+    private Date createdAt;
+
+//    @JsonProperty("user_id")
+    private int userId;
+}

--- a/mydata-service/src/main/java/com/pda/mydata_service/dto/BankAccountResponseDto.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/dto/BankAccountResponseDto.java
@@ -1,0 +1,29 @@
+package com.pda.mydata_service.dto;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Data
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class BankAccountResponseDto {
+
+    private String accountNo;
+
+    private String bankName;
+
+    private String accountType;
+
+    private String name;
+
+    private int balance;
+
+    private Date createdAt;
+
+    private int userId;
+}

--- a/mydata-service/src/main/java/com/pda/mydata_service/jpa/BankAccount.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/jpa/BankAccount.java
@@ -1,0 +1,41 @@
+package com.pda.mydata_service.jpa;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "bank_accounts")
+@Builder
+@AllArgsConstructor
+//@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class BankAccount {
+
+    @Id
+    @Column(name = "account_no")
+    private String accountNo;
+
+    @Column(name = "bank_name")
+    private String bankName;
+
+    @Column(name = "account_type")
+    private String accountType;
+
+    private String name;
+
+    private int balance;
+
+    @Column(name = "created_at")
+    private Date createdAt;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private MydataUser mydataUser;
+}

--- a/mydata-service/src/main/java/com/pda/mydata_service/jpa/BankAccountRepository.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/jpa/BankAccountRepository.java
@@ -1,0 +1,17 @@
+package com.pda.mydata_service.jpa;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface BankAccountRepository extends JpaRepository<BankAccount, String> {
+    Optional<List<BankAccount>> findByMydataUser_Id(int userId);
+//    Optional<List<BankAccount>> findByUserIdAndBankName(int userId, String bankName);
+
+    Optional<List<BankAccount>> findByMydataUser_IdAndBankName(int userId, String bankName);
+
+}

--- a/mydata-service/src/main/java/com/pda/mydata_service/jpa/MydataUser.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/jpa/MydataUser.java
@@ -1,0 +1,17 @@
+package com.pda.mydata_service.jpa;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@Table(name = "users")
+public class MydataUser {
+    @Id
+    private int id;
+
+}

--- a/mydata-service/src/main/java/com/pda/mydata_service/jpa/MydataUserRepository.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/jpa/MydataUserRepository.java
@@ -1,0 +1,6 @@
+package com.pda.mydata_service.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MydataUserRepository extends JpaRepository<MydataUser, Integer> {
+}

--- a/mydata-service/src/main/java/com/pda/mydata_service/service/BankAccountService.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/service/BankAccountService.java
@@ -1,0 +1,11 @@
+package com.pda.mydata_service.service;//package com.pda.mydata_service.legacy.service;
+
+import com.pda.mydata_service.jpa.BankAccount;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface BankAccountService {
+    Optional<List<BankAccount>> getAllBankAccounts(int userId);
+
+}

--- a/mydata-service/src/main/java/com/pda/mydata_service/service/BankAccountServiceImpl.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/service/BankAccountServiceImpl.java
@@ -1,0 +1,24 @@
+package com.pda.mydata_service.service;//package com.pda.mydata_service.legacy.service;
+
+import com.pda.mydata_service.jpa.BankAccount;
+import com.pda.mydata_service.jpa.BankAccountRepository;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@AllArgsConstructor
+@Slf4j
+public class BankAccountServiceImpl implements BankAccountService{
+
+    private final BankAccountRepository bankAccountRepository;
+
+    @Override
+    public Optional<List<BankAccount>> getAllBankAccounts(int userId) {
+        Optional<List<BankAccount>> allBankAccounts = bankAccountRepository.findByMydataUser_Id(userId);
+        return allBankAccounts;
+    }
+}

--- a/mydata-service/src/main/java/com/pda/mydata_service/service/MydataService.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/service/MydataService.java
@@ -1,0 +1,19 @@
+package com.pda.mydata_service.service;//package com.pda.mydata_service.legacy.service;
+
+import com.pda.mydata_service.dto.BankAccountDto;
+import com.pda.mydata_service.jpa.BankAccount;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MydataService {
+
+    BankAccount convertToEntity(BankAccountDto bankAccountDto);
+
+    BankAccountDto convertToDto(BankAccount bankAccount);
+
+    Optional<List<BankAccountDto>> getAllBankAccounts(int userId);
+
+    Optional<List<BankAccountDto>> getBankAccountsByUserIdAndBankName(int userId, String bankName);
+
+}

--- a/mydata-service/src/main/java/com/pda/mydata_service/service/MydataServiceImpl.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/service/MydataServiceImpl.java
@@ -1,0 +1,83 @@
+package com.pda.mydata_service.service;//package com.pda.mydata_service.legacy.service;
+
+
+import com.pda.mydata_service.dto.BankAccountDto;
+import com.pda.mydata_service.jpa.BankAccount;
+import com.pda.mydata_service.jpa.BankAccountRepository;
+import com.pda.mydata_service.jpa.MydataUser;
+import com.pda.mydata_service.jpa.MydataUserRepository;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@AllArgsConstructor
+@Slf4j
+public class MydataServiceImpl implements MydataService{
+
+    private final BankAccountRepository bankAccountRepository;
+    private final MydataUserRepository mydataUserRepository;
+
+    @Override
+    public BankAccount convertToEntity(BankAccountDto bankAccountDto) {
+        MydataUser user = mydataUserRepository.findById(bankAccountDto.getUserId()).orElseThrow();
+        return BankAccount.builder()
+                .accountNo(bankAccountDto.getAccountNo())
+                .bankName(bankAccountDto.getBankName())
+                .accountType(bankAccountDto.getAccountType())
+                .name(bankAccountDto.getName())
+                .balance(bankAccountDto.getBalance())
+                .createdAt(bankAccountDto.getCreatedAt())
+                .mydataUser(user)
+                .build();
+    }
+
+    @Override
+    public BankAccountDto convertToDto(BankAccount bankAccount) {
+        return BankAccountDto.builder()
+                .accountNo(bankAccount.getAccountNo())
+                .bankName(bankAccount.getBankName())
+                .accountType(bankAccount.getAccountType())
+                .name(bankAccount.getName())
+                .balance(bankAccount.getBalance())
+                .createdAt(bankAccount.getCreatedAt())
+                .userId(bankAccount.getMydataUser().getId())
+                .build();
+    }
+
+    @Override
+    public Optional<List<BankAccountDto>> getAllBankAccounts(int userId) {
+        Optional<List<BankAccount>> bankAccounts = bankAccountRepository.findByMydataUser_Id(userId);
+        if (bankAccounts.isPresent()) {
+            List<BankAccountDto> bankAccountDtos = bankAccounts.get().stream()
+                    .map(this::convertToDto)
+                    .toList();
+            return Optional.of(bankAccountDtos);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<List<BankAccountDto>> getBankAccountsByUserIdAndBankName(int userId, String bankName) {
+
+        log.info("mydata service");
+
+
+        Optional<List<BankAccount>> bankAccounts = bankAccountRepository.findByMydataUser_IdAndBankName(userId, bankName);
+        log.info("bank accounts = {}", bankAccounts.get());
+        if (bankAccounts.isPresent()) {
+            List<BankAccountDto> bankAccountDtos = bankAccounts.get().stream()
+                    .map(this::convertToDto)
+                    .toList();
+            log.info("bank accounts bankAccountDtos = {}", bankAccountDtos);
+            return Optional.of(bankAccountDtos);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+}


### PR DESCRIPTION

## 📌 작업 내용 (필수)
- 사용자가 연동할 은행 리스트에 대해 마이데이터 모듈에 해당 은행에 있는 모든 계좌 정보 요청
- BankAccount에 연동한 계좌 저장
- 연동 성공한 경우 연동된 계좌 return 

<br/>

## 🔥 트러블 슈팅 (선택) 
- mydata-service에 요청할 때는 OpenFeign을 통해 API 요청으로 데이터를 받아왔다.
- mydata-service에 데이터를 요청하기 위한 MydataInfo 테이블을 만들어서 정보성으로 기록해두려 했는데, 요청한 데이터를 각 테이블에 저장하면 되었다.(현재는 기록 테이블, 엔티티 테이블에 모두 저장한 상태)

<br/>

## 🌱 관련 이슈 (필수)
- #2 


<br/> 

