### PR TITLE
feat: 마이데이터 연동 기능 구현(카드, 증권, 보험, 연금)

### DIFF
--- a/asset-service/src/main/java/com/pda/asset_service/controller/AssetController.java
+++ b/asset-service/src/main/java/com/pda/asset_service/controller/AssetController.java
@@ -23,6 +23,7 @@ public class AssetController {
 
         List<MydataInfoDto> bankAccountsLinkInfo = assetService.linkMydata(userAccountInfoDto);
 
+
         return ApiUtils.success(bankAccountsLinkInfo);
     }
 }

--- a/asset-service/src/main/java/com/pda/asset_service/controller/AssetController.java
+++ b/asset-service/src/main/java/com/pda/asset_service/controller/AssetController.java
@@ -21,7 +21,7 @@ public class AssetController {
     @PostMapping("/mydata-link")
     public ApiUtils.ApiResult<List<MydataInfoDto>> linkMydata(@RequestBody UserAccountInfoDto userAccountInfoDto){
 
-        List<MydataInfoDto> bankAccountsLinkInfo = assetService.mydataLink(userAccountInfoDto);
+        List<MydataInfoDto> bankAccountsLinkInfo = assetService.linkMydata(userAccountInfoDto);
 
         return ApiUtils.success(bankAccountsLinkInfo);
     }

--- a/asset-service/src/main/java/com/pda/asset_service/dto/CardDto.java
+++ b/asset-service/src/main/java/com/pda/asset_service/dto/CardDto.java
@@ -1,0 +1,39 @@
+package com.pda.asset_service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CardDto {
+    @JsonProperty("card_no")
+    private String cardNo;
+
+    @JsonProperty("company_name")
+    private String companyName;
+
+    @JsonProperty("card_name")
+    private String cardName;
+
+    @JsonProperty("card_type")
+    private String cardType;
+
+    @JsonProperty("created_at")
+    private Date createdAt;
+
+    @JsonProperty("expired_at")
+    private Date expiredAt;
+
+    @JsonProperty("account_no")
+    private String accountNo;
+
+    @JsonProperty("user_id")
+    private int userId;
+}

--- a/asset-service/src/main/java/com/pda/asset_service/dto/CardResponseDto.java
+++ b/asset-service/src/main/java/com/pda/asset_service/dto/CardResponseDto.java
@@ -1,0 +1,32 @@
+package com.pda.asset_service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CardResponseDto {
+
+    private String cardNo;
+
+    private String companyName;
+
+    private String cardName;
+
+    private String cardType;
+
+    private Date createdAt;
+
+    private Date expiredAt;
+
+    private String accountNo;
+
+    private int userId;
+}

--- a/asset-service/src/main/java/com/pda/asset_service/dto/LoanDto.java
+++ b/asset-service/src/main/java/com/pda/asset_service/dto/LoanDto.java
@@ -1,0 +1,34 @@
+package com.pda.asset_service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LoanDto {
+    @JsonProperty("company_name")
+    private String companyName;
+
+    @JsonProperty("loan_type")
+    private String loanType;
+
+    @JsonProperty("loan_amount")
+    private int loanAmount;
+
+    @JsonProperty("interest_rate")
+    private Double interestRate;
+
+    @JsonProperty("total_payments")
+    private int totalPayments;
+
+    @JsonProperty("account_no")
+    private String accountNo;
+
+    @JsonProperty("user_id")
+    private int userId;
+}

--- a/asset-service/src/main/java/com/pda/asset_service/dto/LoanResponseDto.java
+++ b/asset-service/src/main/java/com/pda/asset_service/dto/LoanResponseDto.java
@@ -1,0 +1,27 @@
+package com.pda.asset_service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LoanResponseDto {
+    private String companyName;
+
+    private String loanType;
+
+    private int loanAmount;
+
+    private Double interestRate;
+
+    private int totalPayments;
+
+    private String accountNo;
+
+    private int userId;
+}

--- a/asset-service/src/main/java/com/pda/asset_service/dto/MydataInfoDto.java
+++ b/asset-service/src/main/java/com/pda/asset_service/dto/MydataInfoDto.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class MydataInfoDto {
     private int id;
+    private int userId;
     private String assetType;
     private String companyName;
     private String accountType;

--- a/asset-service/src/main/java/com/pda/asset_service/dto/PensionDto.java
+++ b/asset-service/src/main/java/com/pda/asset_service/dto/PensionDto.java
@@ -1,0 +1,39 @@
+package com.pda.asset_service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PensionDto {
+    @JsonProperty("company_name")
+    private String companyName;
+
+    @JsonProperty("pension_name")
+    private String pensionName;
+
+    @JsonProperty("pension_type")
+    private String pensionType;
+
+    @JsonProperty("interest_rate")
+    private Double interestRate;
+
+    @JsonProperty("evaluation_amount")
+    private String evaluationAmount;
+
+    @JsonProperty("expiration_date")
+    private Date expirationDate;
+
+    @JsonProperty("account_no")
+    private String accountNo;
+
+    @JsonProperty("user_id")
+    private int userId;
+}

--- a/asset-service/src/main/java/com/pda/asset_service/dto/PensionResponseDto.java
+++ b/asset-service/src/main/java/com/pda/asset_service/dto/PensionResponseDto.java
@@ -1,0 +1,31 @@
+package com.pda.asset_service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PensionResponseDto {
+    private String companyName;
+
+    private String pensionName;
+
+    private String pensionType;
+
+    private Double interestRate;
+
+    private String evaluationAmount;
+
+    private Date expirationDate;
+
+    private String accountNo;
+
+    private int userId;
+}

--- a/asset-service/src/main/java/com/pda/asset_service/dto/SecurityAccountDto.java
+++ b/asset-service/src/main/java/com/pda/asset_service/dto/SecurityAccountDto.java
@@ -1,0 +1,32 @@
+package com.pda.asset_service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SecurityAccountDto {
+    @JsonProperty("account_no")
+    private String accountNo;
+
+    @JsonProperty("security_name")
+    private String securityName;
+
+    @JsonProperty("account_type")
+    private String accountType;
+
+    private int balance;
+
+    @JsonProperty("created_at")
+    private Date createdAt;
+
+    @JsonProperty("user_id")
+    private int userId;
+}

--- a/asset-service/src/main/java/com/pda/asset_service/dto/SecurityAccountResponseDto.java
+++ b/asset-service/src/main/java/com/pda/asset_service/dto/SecurityAccountResponseDto.java
@@ -1,0 +1,27 @@
+package com.pda.asset_service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SecurityAccountResponseDto {
+    private String accountNo;
+
+    private String securityName;
+
+    private String accountType;
+
+    private Integer balance;
+
+    private Date createdAt;
+
+    private int userId;
+}

--- a/asset-service/src/main/java/com/pda/asset_service/dto/UserAccountInfoDto.java
+++ b/asset-service/src/main/java/com/pda/asset_service/dto/UserAccountInfoDto.java
@@ -10,8 +10,20 @@ import java.util.List;
 public class UserAccountInfoDto {
     @JsonProperty("user_id")
     private int userId;
+
     @JsonProperty("bank_accounts")
     private List<String> bankAccounts;
+
+    @JsonProperty("security_accounts")
+    private List<String> securityAccounts;
+
+    private List<String> cards;
+
+    private List<String> pensions;
+
+    private List<String> loans;
+
+    private List<String> funds;
 
 
 }

--- a/asset-service/src/main/java/com/pda/asset_service/feign/MydataServiceClient.java
+++ b/asset-service/src/main/java/com/pda/asset_service/feign/MydataServiceClient.java
@@ -1,7 +1,6 @@
 package com.pda.asset_service.feign;
 
-import com.pda.asset_service.dto.BankAccountDto;
-import com.pda.asset_service.dto.BankAccountResponseDto;
+import com.pda.asset_service.dto.*;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -16,5 +15,17 @@ public interface MydataServiceClient {
     List<BankAccountDto> getAllBankAccountData(@PathVariable("userId") int userId);
     @GetMapping("/api/mydata/bank-account/{userId}/{bankName}")
     Optional<List<BankAccountResponseDto>> getBankAccountsByUserIdAndBankName(@PathVariable("userId") int userId, @PathVariable("bankName") String bankName);
+
+    @GetMapping("/api/mydata/loan/{userId}/{companyName}")
+    Optional<List<LoanResponseDto>> getLoansByUserIdAndCompanyName(@PathVariable("userId") int userId, @PathVariable("companyName") String companyName);
+
+    @GetMapping("/api/mydata/card/{userId}/{companyName}")
+    Optional<List<CardResponseDto>> getCardsByUserIdAndCompanyName(@PathVariable("userId") int userId, @PathVariable("companyName") String companyName);
+
+    @GetMapping("/api/mydata/pension/{userId}/{companyName}")
+    Optional<List<PensionResponseDto>> getPensionsByUserIdAndCompanyName(@PathVariable("userId") int userId, @PathVariable("companyName") String companyName);
+
+    @GetMapping("/api/mydata/security-account/{userId}/{securityName}")
+    Optional<List<SecurityAccountResponseDto>> getSecurityAccountsByUserIdAndSecurityName(@PathVariable("userId") int userId, @PathVariable("securityName") String securityName);
 
 }

--- a/asset-service/src/main/java/com/pda/asset_service/jpa/Card.java
+++ b/asset-service/src/main/java/com/pda/asset_service/jpa/Card.java
@@ -1,0 +1,43 @@
+package com.pda.asset_service.jpa;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "cards")
+public class Card {
+    @Id
+    @Column(name = "card_no")
+    private String cardNo;
+
+    @Column(name = "company_name")
+    private String companyName;
+
+    @Column(name = "card_name")
+    private String cardName;
+
+    @Column(name = "card_type")
+    private String cardType;
+
+    @Column(name = "created_at")
+    private Date createdAt;
+
+    @Column(name = "expired_at")
+    private Date expiredAt;
+
+    @Column(name = "account_no")
+    private String accountNo;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private AssetUser assetUser;
+}

--- a/asset-service/src/main/java/com/pda/asset_service/jpa/CardRepository.java
+++ b/asset-service/src/main/java/com/pda/asset_service/jpa/CardRepository.java
@@ -1,0 +1,8 @@
+package com.pda.asset_service.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CardRepository extends JpaRepository<Card, String> {
+}

--- a/asset-service/src/main/java/com/pda/asset_service/jpa/Loan.java
+++ b/asset-service/src/main/java/com/pda/asset_service/jpa/Loan.java
@@ -1,0 +1,39 @@
+package com.pda.asset_service.jpa;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "loans")
+public class Loan {
+
+    @Column(name = "company_name")
+    private String companyName;
+
+    @Column(name = "loan_type")
+    private String loanType;
+
+    @Column(name = "loan_amount")
+    private Integer loanAmount;
+
+    @Column(name = "interest_rate")
+    private Double interestRate;
+
+    @Column(name = "total_payments")
+    private Integer totalPayments;
+
+    @Id
+    @Column(name = "account_no")
+    private String accountNo;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private AssetUser assetUser;
+}

--- a/asset-service/src/main/java/com/pda/asset_service/jpa/LoanRepository.java
+++ b/asset-service/src/main/java/com/pda/asset_service/jpa/LoanRepository.java
@@ -1,0 +1,8 @@
+package com.pda.asset_service.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LoanRepository extends JpaRepository<Loan, String> {
+}

--- a/asset-service/src/main/java/com/pda/asset_service/jpa/MydataInfo.java
+++ b/asset-service/src/main/java/com/pda/asset_service/jpa/MydataInfo.java
@@ -18,6 +18,9 @@ public class MydataInfo {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 
+    @Column(name = "user_id")
+    private int userId;
+
     @Column(name = "asset_type")
     private String assetType;
 

--- a/asset-service/src/main/java/com/pda/asset_service/jpa/MydataInfoRepository.java
+++ b/asset-service/src/main/java/com/pda/asset_service/jpa/MydataInfoRepository.java
@@ -1,8 +1,24 @@
 package com.pda.asset_service.jpa;
 
+import com.pda.asset_service.dto.MydataInfoDto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+@Repository
 public interface MydataInfoRepository extends JpaRepository<MydataInfo, Integer> {
 
     MydataInfo findByAccountNo(String accountNo);
+    MydataInfo findBankAccountByUserIdAndAssetTypeAndCompanyNameAndAccountNo(int id, String bankAccounts, String bankName, String accountNo);
+
+    MydataInfo findCardByUserIdAndAssetTypeAndCompanyNameAndAccountNo(int id, String cards, String companyName, String accountNo);
+
+    MydataInfo findLoanByUserIdAndAssetTypeAndCompanyNameAndAccountNo(int id, String loans, String companyName, String accountNo);
+
+    MydataInfo findPensionByUserIdAndAssetTypeAndCompanyNameAndAccountNo(int id, String pensions, String companyName, String accountNo);
+
+    MydataInfo findSecurityByUserIdAndAssetTypeAndCompanyNameAndAccountNo(int id, String securityAccounts, String securityName, String accountNo);
+
+    List<MydataInfo> findByUserId(int userId);
 }

--- a/asset-service/src/main/java/com/pda/asset_service/jpa/Pension.java
+++ b/asset-service/src/main/java/com/pda/asset_service/jpa/Pension.java
@@ -1,0 +1,44 @@
+package com.pda.asset_service.jpa;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "pensions")
+public class Pension {
+
+    @Column(name = "company_name")
+    private String companyName;
+
+    @Column(name = "pension_name")
+    private String pensionName;
+
+    @Column(name = "pension_type")
+    private String pensionType;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private AssetUser assetUser;
+
+    @Column(name = "interest_rate")
+    private Double interestRate;
+
+    @Column(name = "evaluation_amount")
+    private String evaluationAmount;
+
+    @Column(name = "expiration_date")
+    private Date expirationDate;
+
+    @Id
+    @Column(name = "account_no")
+    private String accountNo;
+}

--- a/asset-service/src/main/java/com/pda/asset_service/jpa/PensionRepository.java
+++ b/asset-service/src/main/java/com/pda/asset_service/jpa/PensionRepository.java
@@ -1,0 +1,8 @@
+package com.pda.asset_service.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PensionRepository extends JpaRepository<Pension, String> {
+}

--- a/asset-service/src/main/java/com/pda/asset_service/jpa/SecurityAccount.java
+++ b/asset-service/src/main/java/com/pda/asset_service/jpa/SecurityAccount.java
@@ -1,0 +1,37 @@
+package com.pda.asset_service.jpa;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "security_accounts")
+public class SecurityAccount {
+
+    @Id
+    @Column(name = "account_no")
+    private String accountNo;
+
+    @Column(name = "security_name")
+    private String securityName;
+
+    @Column(name = "account_type")
+    private String accountType;
+
+    private Integer balance;
+
+    @Column(name = "created_at")
+    private Date createdAt;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private AssetUser assetUser;
+}

--- a/asset-service/src/main/java/com/pda/asset_service/jpa/SecurityAccountRepository.java
+++ b/asset-service/src/main/java/com/pda/asset_service/jpa/SecurityAccountRepository.java
@@ -1,0 +1,8 @@
+package com.pda.asset_service.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SecurityAccountRepository extends JpaRepository<SecurityAccount, String> {
+}

--- a/asset-service/src/main/java/com/pda/asset_service/jpa/SecurityTransaction.java
+++ b/asset-service/src/main/java/com/pda/asset_service/jpa/SecurityTransaction.java
@@ -1,0 +1,4 @@
+package com.pda.asset_service.jpa;
+
+public class SecurityTransaction {
+}

--- a/asset-service/src/main/java/com/pda/asset_service/jpa/SecurityTransactionRespository.java
+++ b/asset-service/src/main/java/com/pda/asset_service/jpa/SecurityTransactionRespository.java
@@ -1,0 +1,6 @@
+package com.pda.asset_service.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SecurityTransactionRespository extends JpaRepository<BankAccount, String> {
+}

--- a/asset-service/src/main/java/com/pda/asset_service/service/AssetService.java
+++ b/asset-service/src/main/java/com/pda/asset_service/service/AssetService.java
@@ -2,11 +2,15 @@ package com.pda.asset_service.service;
 
 import com.pda.asset_service.dto.MydataInfoDto;
 import com.pda.asset_service.dto.UserAccountInfoDto;
+import com.pda.user_service.jpa.User;
 
 
 import java.util.List;
 
 public interface AssetService {
     List<MydataInfoDto> linkMydata(UserAccountInfoDto userAccountInfoDto);
+
+    // 나중에 kafka로 변경 예정
+    User updateMydataStatus(int userId);
 
 }

--- a/asset-service/src/main/java/com/pda/asset_service/service/AssetService.java
+++ b/asset-service/src/main/java/com/pda/asset_service/service/AssetService.java
@@ -7,6 +7,6 @@ import com.pda.asset_service.dto.UserAccountInfoDto;
 import java.util.List;
 
 public interface AssetService {
-    List<MydataInfoDto> mydataLink(UserAccountInfoDto userAccountInfoDto);
+    List<MydataInfoDto> linkMydata(UserAccountInfoDto userAccountInfoDto);
 
 }

--- a/asset-service/src/main/java/com/pda/asset_service/service/AssetServiceImpl.java
+++ b/asset-service/src/main/java/com/pda/asset_service/service/AssetServiceImpl.java
@@ -24,21 +24,13 @@ public class AssetServiceImpl implements AssetService{
     private final SecurityTransactionServiceImpl securityTransactionService;
 
     @Override
-    public List<MydataInfoDto> mydataLink(UserAccountInfoDto userAccountInfoDto) {
-
-
-        // controller에 { "userId": 1,"bankAccounts": ["국민은행", "신한은행"],"securityAccounts": ["신한투자증권"]} 형식으로 요청 온다
-        // service에서는 각 기관을 돌면서 데이터 있는 지 확인
-        // 있으면 mydataInfo에 있다고 저장
-        // responseDto에 담아줌....
+    public List<MydataInfoDto> linkMydata(UserAccountInfoDto userAccountInfoDto) {
 
         int userId = userAccountInfoDto.getUserId();
         log.info("userId = {}", userId);
 
-        List<MydataInfoDto> bankAccountsLinkInfo = bankAccountService.mydataLink(userId,  userAccountInfoDto.getBankAccounts());
+        List<MydataInfoDto> bankAccountsLinkInfo = bankAccountService.linkMyDataAccount(userId,  userAccountInfoDto.getBankAccounts());
         log.info("bankAccountsLinkInfo = {}", bankAccountsLinkInfo);
-
-
 
         return bankAccountsLinkInfo;
     }

--- a/asset-service/src/main/java/com/pda/asset_service/service/AssetServiceImpl.java
+++ b/asset-service/src/main/java/com/pda/asset_service/service/AssetServiceImpl.java
@@ -5,10 +5,16 @@ import com.pda.asset_service.dto.MydataInfoDto;
 import com.pda.asset_service.dto.UserAccountInfoDto;
 import com.pda.asset_service.feign.MydataServiceClient;
 import com.pda.asset_service.jpa.BankAccountRepository;
+import com.pda.asset_service.jpa.MydataInfo;
+import com.pda.asset_service.jpa.MydataInfoRepository;
+import com.pda.user_service.jpa.User;
+import com.pda.user_service.jpa.UserRepository;
+import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -16,23 +22,79 @@ import java.util.List;
 @Slf4j
 public class AssetServiceImpl implements AssetService{
 
-    private final BankAccountRepository bankAccountRepository;
-    private final MydataServiceClient mydataServiceClient;
-
     private final BankAccountServiceImpl bankAccountService;
+    private final SecurityAccountServiceImpl securityAccountService;
     private final CardServiceImpl cardService;
-    private final SecurityTransactionServiceImpl securityTransactionService;
+    private final PensionServiceImpl pensionService;
+    private final LoanServiceImpl loanService;
+//    private final FundServiceImpl fundService;
+
+    private final MydataInfoRepository mydataInfoRepository;
+
+    private final UserRepository userRepository;
 
     @Override
+    @Transactional
     public List<MydataInfoDto> linkMydata(UserAccountInfoDto userAccountInfoDto) {
 
         int userId = userAccountInfoDto.getUserId();
         log.info("userId = {}", userId);
 
-        List<MydataInfoDto> bankAccountsLinkInfo = bankAccountService.linkMyDataAccount(userId,  userAccountInfoDto.getBankAccounts());
-        log.info("bankAccountsLinkInfo = {}", bankAccountsLinkInfo);
+        List<MydataInfoDto> allMydataLinkInfo = new ArrayList<>();
 
-        return bankAccountsLinkInfo;
+        // 은행 계좌
+        List<MydataInfoDto> bankAccountsLinkInfo = bankAccountService.linkMyDataAccount(userId,userAccountInfoDto.getBankAccounts());
+        allMydataLinkInfo.addAll(bankAccountsLinkInfo);
+        log.info("01. bankAccountsLinkInfo = {}", bankAccountsLinkInfo);
+
+        // 증권 계좌
+        List<MydataInfoDto> securityAccountsLinkInfo = securityAccountService.linkMyDataAccount(userId,userAccountInfoDto.getSecurityAccounts());
+        allMydataLinkInfo.addAll(securityAccountsLinkInfo);
+        log.info("02. securityAccountsLinkInfo = {}", securityAccountsLinkInfo);
+
+        // 카드
+        List<MydataInfoDto> cardsLinkInfo = cardService.linkMyDataAccount(userId,userAccountInfoDto.getCards());
+        allMydataLinkInfo.addAll(cardsLinkInfo);
+        log.info("03. cardsLinkInfo = {}", cardsLinkInfo);
+
+        // 연금
+        List<MydataInfoDto> pensionsLinkInfo = pensionService.linkMyDataAccount(userId,userAccountInfoDto.getPensions());
+        allMydataLinkInfo.addAll(pensionsLinkInfo);
+        log.info("04. pensionsLinkInfo = {}", pensionsLinkInfo);
+
+        // 대출
+        List<MydataInfoDto> loansLinkInfo = loanService.linkMyDataAccount(userId,userAccountInfoDto.getLoans());
+        allMydataLinkInfo.addAll(loansLinkInfo);
+        log.info("05. loansLinkInfo = {}", loansLinkInfo);
+
+//        // 펀드
+//        List<MydataInfoDto> fundsLinkInfo = fundService.linkMyDataAccount(userId,userAccountInfoDto.getFunds());
+//        allMydataLinkInfo.addAll(fundsLinkInfo);
+//        log.info("06. fundsLinkInfo = {}", fundsLinkInfo);
+
+        // mq로 요청 필요...
+
+       User updatedUser =  updateMydataStatus(userId);
+       log.info("Mydata Link Updated User Info = {}", updatedUser);
+        return allMydataLinkInfo;
     }
+
+    @Override
+    public User updateMydataStatus(int userId) {
+        // mdyata info 테이블 결과 있는지 확인
+        List<MydataInfo> mydataLinkedList = mydataInfoRepository.findByUserId(userId);
+
+        // user repository 값 변경하라고 요청
+        if (!mydataLinkedList.isEmpty()) {
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new RuntimeException("User not found"));
+            user.setMydata("Y");
+            return userRepository.save(user);
+        }
+
+        return null;
+    }
+
+
 
 }

--- a/asset-service/src/main/java/com/pda/asset_service/service/BankAccountService.java
+++ b/asset-service/src/main/java/com/pda/asset_service/service/BankAccountService.java
@@ -13,5 +13,5 @@ public interface BankAccountService {
 
     BankAccountDto convertToDto(BankAccount bankAccount);
 
-    List<MydataInfoDto> mydataLink(int userId, List<String> bankAccounts);
+    List<MydataInfoDto> linkMyDataAccount(int userId, List<String> bankAccounts);
 }

--- a/asset-service/src/main/java/com/pda/asset_service/service/BankAccountServiceImpl.java
+++ b/asset-service/src/main/java/com/pda/asset_service/service/BankAccountServiceImpl.java
@@ -53,7 +53,7 @@ public class BankAccountServiceImpl implements BankAccountService{
     }
 
     @Override
-    public List<MydataInfoDto> mydataLink(int userId, List<String> bankAccounts) {
+    public List<MydataInfoDto> linkMyDataAccount(int userId, List<String> bankAccounts) {
 
         List<MydataInfoDto> bankAccountsLinkInfo = new ArrayList<>();
 

--- a/asset-service/src/main/java/com/pda/asset_service/service/CardService.java
+++ b/asset-service/src/main/java/com/pda/asset_service/service/CardService.java
@@ -1,0 +1,16 @@
+package com.pda.asset_service.service;
+
+import com.pda.asset_service.dto.*;
+import com.pda.asset_service.jpa.BankAccount;
+import com.pda.asset_service.jpa.Card;
+
+import java.util.List;
+
+public interface CardService {
+
+    Card convertToEntity(CardResponseDto cardResponseDto);
+
+    CardDto convertToDto(Card card);
+
+    List<MydataInfoDto> linkMyDataAccount(int userId, List<String> cards);
+}

--- a/asset-service/src/main/java/com/pda/asset_service/service/CardServiceImpl.java
+++ b/asset-service/src/main/java/com/pda/asset_service/service/CardServiceImpl.java
@@ -1,0 +1,104 @@
+package com.pda.asset_service.service;
+
+import com.pda.asset_service.dto.CardDto;
+import com.pda.asset_service.dto.CardResponseDto;
+import com.pda.asset_service.dto.MydataInfoDto;
+import com.pda.asset_service.feign.MydataServiceClient;
+import com.pda.asset_service.jpa.*;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@AllArgsConstructor
+@Slf4j
+public class CardServiceImpl implements CardService{
+
+    private final CardRepository cardRepository;
+    private final AssetUserRepository assetUserRepository;
+    private final MydataInfoRepository mydataInfoRepository;
+    private final MydataServiceClient mydataServiceClient;
+    @Override
+    public Card convertToEntity(CardResponseDto cardResponseDto) {
+        AssetUser assetUser = assetUserRepository.findById(cardResponseDto.getUserId()).orElseThrow();
+        return Card.builder()
+                .cardNo(cardResponseDto.getCardNo())
+                .companyName(cardResponseDto.getCompanyName())
+                .cardName(cardResponseDto.getCardName())
+                .cardType(cardResponseDto.getCardType())
+                .createdAt(cardResponseDto.getCreatedAt())
+                .expiredAt(cardResponseDto.getExpiredAt())
+                .accountNo(cardResponseDto.getAccountNo())
+                .assetUser(assetUser)
+                .build();
+    }
+
+    @Override
+    public CardDto convertToDto(Card card) {
+        return CardDto.builder()
+                .cardNo(card.getCardNo())
+                .companyName(card.getCompanyName())
+                .cardName(card.getCardName())
+                .cardType(card.getCardType())
+                .createdAt(card.getCreatedAt())
+                .expiredAt(card.getExpiredAt())
+                .accountNo(card.getAccountNo())
+                .userId(card.getAssetUser().getId())
+                .build();
+    }
+
+    @Override
+    public List<MydataInfoDto> linkMyDataAccount(int userId, List<String> cards) {
+        List<MydataInfoDto> cardLinkInfo = new ArrayList<>();
+
+        // 카드 정보 처리
+
+        for (String cardName : cards) {
+            if( !cardName.isEmpty() ) {
+                log.info("userCard = {}", cardName);
+                Optional<List<CardResponseDto>> cardResponse = mydataServiceClient.getCardsByUserIdAndCompanyName(userId, cardName);
+                log.info("cards Response From Mydata-service = {}", cardResponse);
+                if (cardResponse.isPresent()) {
+                    log.info("==========================================================================");
+                    for (CardResponseDto cardResponseDto : cardResponse.get()) {
+                        log.info("card convert Entity = {}", cardResponseDto);
+                        Card card = convertToEntity(cardResponseDto);
+                        log.info("========================== = {}", card);
+                        cardRepository.save(card);
+                        log.info("card Saved = {}", card);
+
+                        mydataInfoRepository.save(MydataInfo.builder()
+                                .assetType("cards")
+                                .userId(card.getAssetUser().getId())
+                                .companyName(card.getCompanyName())
+                                .accountType(card.getCardType())
+                                .accountNo(card.getCardNo())
+                                .build());
+
+                        MydataInfo savedInfo = mydataInfoRepository.findCardByUserIdAndAssetTypeAndCompanyNameAndAccountNo(
+                                card.getAssetUser().getId(),
+                                "cards",
+                                card.getCompanyName(),
+                                card.getAccountNo()
+                        );
+                        MydataInfoDto mydataInfoDto = MydataInfoDto.builder()
+                                .assetType(savedInfo.getAssetType())
+                                .userId(savedInfo.getUserId())
+                                .companyName(savedInfo.getCompanyName())
+                                .accountType(savedInfo.getAccountType())
+                                .accountNo(card.getCardNo())
+                                .build();
+
+                        cardLinkInfo.add(mydataInfoDto);
+                    }
+                }
+            }
+        }
+        return cardLinkInfo;
+    }
+
+}

--- a/asset-service/src/main/java/com/pda/asset_service/service/LoanService.java
+++ b/asset-service/src/main/java/com/pda/asset_service/service/LoanService.java
@@ -1,0 +1,17 @@
+package com.pda.asset_service.service;
+
+
+import com.pda.asset_service.dto.*;
+import com.pda.asset_service.jpa.BankAccount;
+import com.pda.asset_service.jpa.Loan;
+
+import java.util.List;
+
+public interface LoanService {
+
+    Loan convertToEntity(LoanResponseDto loanResponseDto);
+
+    LoanDto convertToDto(Loan loan);
+
+    List<MydataInfoDto> linkMyDataAccount(int userId, List<String> loans);
+}

--- a/asset-service/src/main/java/com/pda/asset_service/service/LoanServiceImpl.java
+++ b/asset-service/src/main/java/com/pda/asset_service/service/LoanServiceImpl.java
@@ -1,0 +1,99 @@
+package com.pda.asset_service.service;
+
+import com.pda.asset_service.dto.LoanDto;
+import com.pda.asset_service.dto.LoanResponseDto;
+import com.pda.asset_service.dto.MydataInfoDto;
+import com.pda.asset_service.feign.MydataServiceClient;
+import com.pda.asset_service.jpa.*;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@AllArgsConstructor
+@Slf4j
+public class LoanServiceImpl implements LoanService{
+
+    private final LoanRepository loanRepository;
+    private final AssetUserRepository assetUserRepository;
+    private final MydataInfoRepository mydataInfoRepository;
+    private final MydataServiceClient mydataServiceClient;
+
+    @Override
+    public Loan convertToEntity(LoanResponseDto loanResponseDto) {
+        AssetUser user = assetUserRepository.findById(loanResponseDto.getUserId()).orElseThrow();
+        return Loan.builder()
+                .companyName(loanResponseDto.getCompanyName())
+                .loanType(loanResponseDto.getLoanType())
+                .loanAmount(loanResponseDto.getLoanAmount())
+                .interestRate(loanResponseDto.getInterestRate())
+                .totalPayments(loanResponseDto.getTotalPayments())
+                .accountNo(loanResponseDto.getAccountNo())
+                .assetUser(user)
+                .build();
+    }
+
+    @Override
+    public LoanDto convertToDto(Loan loan) {
+        return LoanDto.builder()
+                .companyName(loan.getCompanyName())
+                .loanType(loan.getLoanType())
+                .loanAmount(loan.getLoanAmount())
+                .interestRate(loan.getInterestRate())
+                .totalPayments(loan.getTotalPayments())
+                .accountNo(loan.getAccountNo())
+                .userId(loan.getAssetUser().getId())
+                .build();
+    }
+
+    @Override
+    public List<MydataInfoDto> linkMyDataAccount(int userId, List<String> loans) {
+        List<MydataInfoDto> loanLinkInfo = new ArrayList<>();
+
+        // 대출 정보 처리
+
+        for (String loanName : loans) {
+            if( !loans.isEmpty()) {
+                log.info("userAccount = {}", loanName);
+                Optional<List<LoanResponseDto>> loanResponse = mydataServiceClient.getLoansByUserIdAndCompanyName(userId, loanName);
+                if (loanResponse.isPresent()) {
+                    for (LoanResponseDto loanResponseDto : loanResponse.get()) {
+                        Loan loan = convertToEntity(loanResponseDto);
+                        loanRepository.save(loan);
+
+                        mydataInfoRepository.save(MydataInfo.builder()
+                                .assetType("loans")
+                                .userId(loan.getAssetUser().getId())
+                                .companyName(loan.getCompanyName())
+                                .accountType(loan.getLoanType())
+                                .accountNo(loan.getAccountNo())
+                                .build());
+
+                        MydataInfo savedInfo = mydataInfoRepository.findLoanByUserIdAndAssetTypeAndCompanyNameAndAccountNo(
+                                loan.getAssetUser().getId(),
+                                "loans",
+                                loan.getCompanyName(),
+                                loan.getAccountNo()
+                        );
+                        MydataInfoDto mydataInfoDto = MydataInfoDto.builder()
+                                .assetType(savedInfo.getAssetType())
+                                .userId(savedInfo.getUserId())
+                                .companyName(savedInfo.getCompanyName())
+                                .accountType(savedInfo.getAccountType())
+                                .accountNo(loan.getAccountNo())
+                                .build();
+
+                        loanLinkInfo.add(mydataInfoDto);
+                    }
+                }
+            }
+        }
+        return loanLinkInfo;
+    }
+
+
+}

--- a/asset-service/src/main/java/com/pda/asset_service/service/PensionService.java
+++ b/asset-service/src/main/java/com/pda/asset_service/service/PensionService.java
@@ -1,0 +1,16 @@
+package com.pda.asset_service.service;
+
+import com.pda.asset_service.dto.*;
+import com.pda.asset_service.jpa.BankAccount;
+import com.pda.asset_service.jpa.Pension;
+
+import java.util.List;
+
+public interface PensionService {
+
+    Pension convertToEntity(PensionResponseDto pensionResponseDto);
+
+    PensionDto convertToDto(Pension pension);
+
+    List<MydataInfoDto> linkMyDataAccount(int userId, List<String> pensions);
+}

--- a/asset-service/src/main/java/com/pda/asset_service/service/PensionServiceImpl.java
+++ b/asset-service/src/main/java/com/pda/asset_service/service/PensionServiceImpl.java
@@ -1,0 +1,101 @@
+package com.pda.asset_service.service;
+
+import com.pda.asset_service.dto.MydataInfoDto;
+import com.pda.asset_service.dto.PensionDto;
+import com.pda.asset_service.dto.PensionResponseDto;
+import com.pda.asset_service.feign.MydataServiceClient;
+import com.pda.asset_service.jpa.*;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@AllArgsConstructor
+@Slf4j
+public class PensionServiceImpl implements PensionService{
+
+    private final PensionRepository pensionRepository;
+    private final AssetUserRepository assetUserRepository;
+    private final MydataInfoRepository mydataInfoRepository;
+    private final MydataServiceClient mydataServiceClient;
+
+    @Override
+    public Pension convertToEntity(PensionResponseDto pensionResponseDto) {
+        AssetUser user = assetUserRepository.findById(pensionResponseDto.getUserId()).orElseThrow();
+        return Pension.builder()
+                .companyName(pensionResponseDto.getCompanyName())
+                .pensionName(pensionResponseDto.getPensionName())
+                .pensionType(pensionResponseDto.getPensionType())
+                .assetUser(user)
+                .interestRate(pensionResponseDto.getInterestRate())
+                .evaluationAmount(pensionResponseDto.getEvaluationAmount())
+                .expirationDate(pensionResponseDto.getExpirationDate())
+                .accountNo(pensionResponseDto.getAccountNo())
+                .build();
+    }
+
+    @Override
+    public PensionDto convertToDto(Pension pension) {
+        return PensionDto.builder()
+                .companyName(pension.getCompanyName())
+                .pensionName(pension.getPensionName())
+                .pensionType(pension.getPensionType())
+                .userId(pension.getAssetUser().getId())
+                .interestRate(pension.getInterestRate())
+                .evaluationAmount(pension.getEvaluationAmount())
+                .expirationDate(pension.getExpirationDate())
+                .accountNo(pension.getAccountNo())
+                .build();
+    }
+
+    @Override
+    public List<MydataInfoDto> linkMyDataAccount(int userId, List<String> pensions) {
+        List<MydataInfoDto> pensionLinkInfo = new ArrayList<>();
+
+        // 연금 정보 처리
+
+        for (String pensionName : pensions) {
+            if (!pensionName.isEmpty()) {
+                log.info("userPension = {}", pensionName);
+                Optional<List<PensionResponseDto>> pensionResponse = mydataServiceClient.getPensionsByUserIdAndCompanyName(userId, pensionName);
+                if (pensionResponse.isPresent()) {
+                    log.info("==========================================================================");
+                    for (PensionResponseDto pensionResponseDto : pensionResponse.get()) {
+                        log.info("pension convert Entity = {}", pensionResponseDto);
+                        Pension pension = convertToEntity(pensionResponseDto);
+                        pensionRepository.save(pension);
+                        mydataInfoRepository.save(MydataInfo.builder()
+                                .assetType("pensions")
+                                .userId(pension.getAssetUser().getId())
+                                .companyName(pension.getCompanyName())
+                                .accountType(pension.getPensionType())
+                                .accountNo(pension.getAccountNo())
+                                .build());
+
+                        MydataInfo savedInfo = mydataInfoRepository.findPensionByUserIdAndAssetTypeAndCompanyNameAndAccountNo(
+                                pension.getAssetUser().getId(),
+                                "pensions",
+                                pension.getCompanyName(),
+                                pension.getAccountNo()
+                        );
+                        MydataInfoDto mydataInfoDto = MydataInfoDto.builder()
+                                .assetType(savedInfo.getAssetType())
+                                .userId(savedInfo.getUserId())
+                                .companyName(savedInfo.getCompanyName())
+                                .accountType(savedInfo.getAccountType())
+                                .accountNo(pension.getAccountNo())
+                                .build();
+
+                        pensionLinkInfo.add(mydataInfoDto);
+                    }
+                }
+            }
+        }
+        return pensionLinkInfo;
+    }
+
+}

--- a/asset-service/src/main/java/com/pda/asset_service/service/SecurityAccountService.java
+++ b/asset-service/src/main/java/com/pda/asset_service/service/SecurityAccountService.java
@@ -1,0 +1,15 @@
+package com.pda.asset_service.service;
+
+import com.pda.asset_service.dto.*;
+import com.pda.asset_service.jpa.BankAccount;
+import com.pda.asset_service.jpa.SecurityAccount;
+
+import java.util.List;
+
+public interface SecurityAccountService {
+    SecurityAccount convertToEntity(SecurityAccountResponseDto securityAccountResponseDto);
+
+    SecurityAccountDto convertToDto(SecurityAccount securityAccount);
+
+    List<MydataInfoDto> linkMyDataAccount(int userId, List<String> securityAccounts);
+}

--- a/asset-service/src/main/java/com/pda/asset_service/service/SecurityAccountServiceImpl.java
+++ b/asset-service/src/main/java/com/pda/asset_service/service/SecurityAccountServiceImpl.java
@@ -1,0 +1,97 @@
+package com.pda.asset_service.service;
+
+import com.pda.asset_service.dto.MydataInfoDto;
+import com.pda.asset_service.dto.SecurityAccountDto;
+import com.pda.asset_service.dto.SecurityAccountResponseDto;
+import com.pda.asset_service.feign.MydataServiceClient;
+import com.pda.asset_service.jpa.*;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@AllArgsConstructor
+@Slf4j
+public class SecurityAccountServiceImpl implements SecurityAccountService{
+
+    private final SecurityAccountRepository securityAccountRepository;
+    private final AssetUserRepository assetUserRepository;
+    private final MydataInfoRepository mydataInfoRepository;
+    private final MydataServiceClient mydataServiceClient;
+    @Override
+    public SecurityAccount convertToEntity(SecurityAccountResponseDto securityAccountResponseDto) {
+        AssetUser assetUser = assetUserRepository.findById(securityAccountResponseDto.getUserId()).orElseThrow();
+        return SecurityAccount.builder()
+                .accountNo(securityAccountResponseDto.getAccountNo())
+                .securityName(securityAccountResponseDto.getSecurityName())
+                .accountType(securityAccountResponseDto.getAccountType())
+                .balance(securityAccountResponseDto.getBalance())
+                .createdAt(securityAccountResponseDto.getCreatedAt())
+                .assetUser(assetUser)
+                .build();
+    }
+
+    @Override
+    public SecurityAccountDto convertToDto(SecurityAccount securityAccount) {
+        return SecurityAccountDto.builder()
+                .accountNo(securityAccount.getAccountNo())
+                .securityName(securityAccount.getSecurityName())
+                .accountType(securityAccount.getAccountType())
+                .balance(securityAccount.getBalance())
+                .createdAt(securityAccount.getCreatedAt())
+                .userId(securityAccount.getAssetUser().getId())
+                .build();
+    }
+
+    @Override
+    public List<MydataInfoDto> linkMyDataAccount(int userId, List<String> securityAccounts) {
+        List<MydataInfoDto> securityAccountsLinkInfo = new ArrayList<>();
+
+        // 증권 계좌 정보 처리
+
+        for (String securityName : securityAccounts) {
+            if( !securityAccounts.isEmpty() ) {
+                log.info("userAccount = {}", securityName);
+                Optional<List<SecurityAccountResponseDto>> securityAccountsResponse = mydataServiceClient.getSecurityAccountsByUserIdAndSecurityName(userId, securityName);
+//            log.info("securityAccounts Response From Mydata-service = {}", securityAccountsResponse);
+                if (securityAccountsResponse.isPresent()) {
+                    for (SecurityAccountResponseDto securityAccountResponseDto : securityAccountsResponse.get()) {
+                        log.info("security account convert Entity = {}", securityAccountResponseDto);
+                        SecurityAccount securityAccount = convertToEntity(securityAccountResponseDto);
+                        securityAccountRepository.save(securityAccount);
+
+                        mydataInfoRepository.save(MydataInfo.builder()
+                                .assetType("security_accounts")
+                                .userId(securityAccount.getAssetUser().getId())
+                                .companyName(securityAccount.getSecurityName())
+                                .accountType(securityAccount.getAccountType())
+                                .accountNo(securityAccount.getAccountNo())
+                                .build());
+
+                        MydataInfo savedInfo = mydataInfoRepository.findSecurityByUserIdAndAssetTypeAndCompanyNameAndAccountNo(
+                                securityAccount.getAssetUser().getId(),
+                                "security_accounts",
+                                securityAccount.getSecurityName(),
+                                securityAccount.getAccountNo()
+                        );
+                        MydataInfoDto mydataInfoDto = MydataInfoDto.builder()
+                                .assetType(savedInfo.getAssetType())
+                                .userId(savedInfo.getUserId())
+                                .companyName(savedInfo.getCompanyName())
+                                .accountType(savedInfo.getAccountType())
+                                .accountNo(securityAccount.getAccountNo())
+                                .build();
+
+                        securityAccountsLinkInfo.add(mydataInfoDto);
+                    }
+                }
+            }
+        }
+        return securityAccountsLinkInfo;
+    }
+
+}

--- a/asset-service/src/main/java/com/pda/asset_service/service/SecurityTransactionService.java
+++ b/asset-service/src/main/java/com/pda/asset_service/service/SecurityTransactionService.java
@@ -1,0 +1,5 @@
+package com.pda.asset_service.service;
+
+
+public interface SecurityTransactionService {
+}

--- a/asset-service/src/main/java/com/pda/asset_service/service/SecurityTransactionServiceImpl.java
+++ b/asset-service/src/main/java/com/pda/asset_service/service/SecurityTransactionServiceImpl.java
@@ -1,0 +1,14 @@
+package com.pda.asset_service.service;
+
+import com.pda.asset_service.jpa.SecurityTransactionRespository;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+@Slf4j
+public class SecurityTransactionServiceImpl implements SecurityTransactionService{
+
+    private final SecurityTransactionRespository securityTransactionRespository;
+}

--- a/mydata-service/src/main/java/com/pda/mydata_service/controller/MydataController.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/controller/MydataController.java
@@ -1,6 +1,6 @@
 package com.pda.mydata_service.controller;
 
-import com.pda.mydata_service.dto.BankAccountDto;
+import com.pda.mydata_service.dto.*;
 import com.pda.mydata_service.service.BankAccountServiceImpl;
 import com.pda.mydata_service.service.MydataServiceImpl;
 import com.pda.utils.api_utils.ApiUtils;
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 import java.util.Optional;
 
+
 @RestController
 @Slf4j
 @RequestMapping("/api/mydata")
@@ -21,21 +22,45 @@ import java.util.Optional;
 public class MydataController {
 
     private final MydataServiceImpl mydataService;
-    private final BankAccountServiceImpl bankAccountService;
 
-//    @GetMapping("/bank-account/")
-//    public ApiUtils.ApiResult<Optional<List<BankAccountDto>>> getBankAccountData(@RequestParam int userId ){
-//        return ApiUtils.success(mydataService.getAllBankAccounts(userId));
-//    }
+
     @GetMapping("/bank-account/{userId}/{bankName}")
     public Optional<List<BankAccountDto>> getBankAccountsByUserIdAndBankName(
             @PathVariable("userId") int userId,
             @PathVariable("bankName") String bankName) {
-
-        log.info("mydata controller");
-
         Optional<List<BankAccountDto>> bankAccounts = mydataService.getBankAccountsByUserIdAndBankName(userId, bankName);
-        log.info("mydata controller result = {}", bankAccounts);
         return bankAccounts;
+    }
+
+    @GetMapping("/loan/{userId}/{loanName}")
+    public Optional<List<LoanDto>> getLoansByUserIdAndCompanyName(
+            @PathVariable("userId") int userId,
+            @PathVariable("loanName") String companyName) {
+        Optional<List<LoanDto>> loans = mydataService.getLoansByUserIdAndCompanyName(userId, companyName);
+        return loans;
+    }
+
+    @GetMapping("/card/{userId}/{cardName}")
+    public Optional<List<CardDto>> getCardsByUserIdAndCompanyName(
+            @PathVariable("userId") int userId,
+            @PathVariable("cardName") String companyName) {
+        Optional<List<CardDto>> cards = mydataService.getCardsByUserIdAndCompanyName(userId, companyName);
+        return cards;
+    }
+
+    @GetMapping("/pension/{userId}/{pensionName}")
+    public Optional<List<PensionDto>> getPensionsByUserIdAndCompanyName(
+            @PathVariable("userId") int userId,
+            @PathVariable("pensionName") String companyName) {
+        Optional<List<PensionDto>> pensions = mydataService.getPensionsByUserIdAndCompanyName(userId, companyName);
+        return pensions;
+    }
+
+    @GetMapping("/security-account/{userId}/{securityName}")
+    public Optional<List<SecurityAccountDto>> getSecurityAccountsByUserIdAndSecurityName(
+            @PathVariable("userId") int userId,
+            @PathVariable("securityName") String securityName) {
+        Optional<List<SecurityAccountDto>> securityAccounts = mydataService.getSecurityAccountsByUserIdAndSecurityName(userId, securityName);
+        return securityAccounts;
     }
 }

--- a/mydata-service/src/main/java/com/pda/mydata_service/dto/CardDto.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/dto/CardDto.java
@@ -1,0 +1,32 @@
+package com.pda.mydata_service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CardDto {
+
+    private String cardNo;
+
+    private String companyName;
+
+    private String cardName;
+
+    private String cardType;
+
+    private Date createdAt;
+
+    private Date expiredAt;
+
+    private String accountNo;
+
+    private int userId;
+}

--- a/mydata-service/src/main/java/com/pda/mydata_service/dto/LoanDto.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/dto/LoanDto.java
@@ -1,0 +1,27 @@
+package com.pda.mydata_service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LoanDto {
+    private String companyName;
+
+    private String loanType;
+
+    private int loanAmount;
+
+    private Double interestRate;
+
+    private int totalPayments;
+
+    private String accountNo;
+
+    private int userId;
+}

--- a/mydata-service/src/main/java/com/pda/mydata_service/dto/PensionDto.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/dto/PensionDto.java
@@ -1,0 +1,31 @@
+package com.pda.mydata_service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PensionDto {
+    private String companyName;
+
+    private String pensionName;
+
+    private String pensionType;
+
+    private Double interestRate;
+
+    private String evaluationAmount;
+
+    private Date expirationDate;
+
+    private String accountNo;
+
+    private int userId;
+}

--- a/mydata-service/src/main/java/com/pda/mydata_service/dto/SecurityAccountDto.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/dto/SecurityAccountDto.java
@@ -1,4 +1,5 @@
 package com.pda.mydata_service.dto;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -9,17 +10,14 @@ import java.util.Date;
 
 @Data
 @NoArgsConstructor
-@Builder
 @AllArgsConstructor
-public class BankAccountResponseDto {
-
+@Builder
+public class SecurityAccountDto {
     private String accountNo;
 
-    private String bankName;
+    private String securityName;
 
     private String accountType;
-
-    private String name;
 
     private int balance;
 

--- a/mydata-service/src/main/java/com/pda/mydata_service/jpa/Card.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/jpa/Card.java
@@ -1,0 +1,43 @@
+package com.pda.mydata_service.jpa;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "cards")
+public class Card {
+    @Id
+    @Column(name = "card_no")
+    private String cardNo;
+
+    @Column(name = "company_name")
+    private String companyName;
+
+    @Column(name = "card_name")
+    private String cardName;
+
+    @Column(name = "card_type")
+    private String cardType;
+
+    @Column(name = "created_at")
+    private Date createdAt;
+
+    @Column(name = "expired_at")
+    private Date expiredAt;
+
+    @Column(name = "account_no")
+    private String accountNo;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private MydataUser mydataUser;
+}

--- a/mydata-service/src/main/java/com/pda/mydata_service/jpa/CardRepository.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/jpa/CardRepository.java
@@ -1,0 +1,15 @@
+package com.pda.mydata_service.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CardRepository extends JpaRepository<Card, String> {
+    Optional<List<Card>> findByMydataUser_Id(int userId);
+
+    Optional<List<Card>> findByMydataUser_IdAndCompanyName(int userId, String cardName);
+
+}

--- a/mydata-service/src/main/java/com/pda/mydata_service/jpa/Loan.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/jpa/Loan.java
@@ -1,0 +1,40 @@
+package com.pda.mydata_service.jpa;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "loans")
+public class Loan {
+
+
+    @Column(name = "company_name")
+    private String companyName;
+
+    @Column(name = "loan_type")
+    private String loanType;
+
+    @Column(name = "loan_amount")
+    private Integer loanAmount;
+
+    @Column(name = "interest_rate")
+    private Double interestRate;
+
+    @Column(name = "total_payments")
+    private Integer totalPayments;
+
+    @Id
+    @Column(name = "account_no")
+    private String accountNo;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private MydataUser mydataUser;
+}

--- a/mydata-service/src/main/java/com/pda/mydata_service/jpa/LoanRepository.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/jpa/LoanRepository.java
@@ -1,0 +1,14 @@
+package com.pda.mydata_service.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface LoanRepository extends JpaRepository<Loan, String> {
+    Optional<List<Loan>> findByMydataUser_Id(int userId);
+
+    Optional<List<Loan>> findByMydataUser_IdAndCompanyName(int userId, String companyName);
+}

--- a/mydata-service/src/main/java/com/pda/mydata_service/jpa/Pension.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/jpa/Pension.java
@@ -1,0 +1,44 @@
+package com.pda.mydata_service.jpa;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "pensions")
+public class Pension {
+
+    @Column(name = "company_name")
+    private String companyName;
+
+    @Column(name = "pension_name")
+    private String pensionName;
+
+    @Column(name = "pension_type")
+    private String pensionType;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private MydataUser mydataUser;
+
+    @Column(name = "interest_rate")
+    private Double interestRate;
+
+    @Column(name = "evaluation_amount")
+    private String evaluationAmount;
+
+    @Column(name = "expiration_date")
+    private Date expirationDate;
+
+    @Id
+    @Column(name = "account_no")
+    private String accountNo;
+}

--- a/mydata-service/src/main/java/com/pda/mydata_service/jpa/PensionRepository.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/jpa/PensionRepository.java
@@ -1,0 +1,15 @@
+package com.pda.mydata_service.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface PensionRepository extends JpaRepository<Pension, String> {
+
+    Optional<List<Pension>> findByMydataUser_Id(int userId);
+
+    Optional<List<Pension>> findByMydataUser_IdAndCompanyName(int userId, String companyName);
+}

--- a/mydata-service/src/main/java/com/pda/mydata_service/jpa/SecurityAccount.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/jpa/SecurityAccount.java
@@ -1,0 +1,37 @@
+package com.pda.mydata_service.jpa;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "security_accounts")
+public class SecurityAccount {
+
+    @Id
+    @Column(name = "account_no")
+    private String accountNo;
+
+    @Column(name = "security_name")
+    private String securityName;
+
+    @Column(name = "account_type")
+    private String accountType;
+
+    private Integer balance;
+
+    @Column(name = "created_at")
+    private Date createdAt;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private MydataUser mydataUser;
+}

--- a/mydata-service/src/main/java/com/pda/mydata_service/jpa/SecurityAccountRepository.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/jpa/SecurityAccountRepository.java
@@ -1,0 +1,15 @@
+package com.pda.mydata_service.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface SecurityAccountRepository extends JpaRepository<SecurityAccount, String> {
+
+    Optional<List<SecurityAccount>> findByMydataUser_Id(int userId);
+
+    Optional<List<SecurityAccount>> findByMydataUser_IdAndSecurityName(int userId, String securityAccountName);
+}

--- a/mydata-service/src/main/java/com/pda/mydata_service/service/MydataService.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/service/MydataService.java
@@ -1,6 +1,6 @@
 package com.pda.mydata_service.service;//package com.pda.mydata_service.legacy.service;
 
-import com.pda.mydata_service.dto.BankAccountDto;
+import com.pda.mydata_service.dto.*;
 import com.pda.mydata_service.jpa.BankAccount;
 
 import java.util.List;
@@ -16,4 +16,11 @@ public interface MydataService {
 
     Optional<List<BankAccountDto>> getBankAccountsByUserIdAndBankName(int userId, String bankName);
 
+    Optional<List<LoanDto>> getLoansByUserIdAndCompanyName(int userId, String companyName);
+
+    Optional<List<CardDto>> getCardsByUserIdAndCompanyName(int userId, String companyName);
+
+    Optional<List<PensionDto>> getPensionsByUserIdAndCompanyName(int userId, String companyName);
+
+    Optional<List<SecurityAccountDto>> getSecurityAccountsByUserIdAndSecurityName(int userId, String securityName);
 }

--- a/mydata-service/src/main/java/com/pda/mydata_service/service/MydataServiceImpl.java
+++ b/mydata-service/src/main/java/com/pda/mydata_service/service/MydataServiceImpl.java
@@ -1,11 +1,8 @@
 package com.pda.mydata_service.service;//package com.pda.mydata_service.legacy.service;
 
 
-import com.pda.mydata_service.dto.BankAccountDto;
-import com.pda.mydata_service.jpa.BankAccount;
-import com.pda.mydata_service.jpa.BankAccountRepository;
-import com.pda.mydata_service.jpa.MydataUser;
-import com.pda.mydata_service.jpa.MydataUserRepository;
+import com.pda.mydata_service.dto.*;
+import com.pda.mydata_service.jpa.*;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -18,8 +15,14 @@ import java.util.Optional;
 @Slf4j
 public class MydataServiceImpl implements MydataService{
 
-    private final BankAccountRepository bankAccountRepository;
+
     private final MydataUserRepository mydataUserRepository;
+
+    private final BankAccountRepository bankAccountRepository;
+    private final CardRepository cardRepository;
+    private final SecurityAccountRepository securityAccountRepository;
+    private final LoanRepository loanRepository;
+    private final PensionRepository pensionRepository;
 
     @Override
     public BankAccount convertToEntity(BankAccountDto bankAccountDto) {
@@ -66,7 +69,6 @@ public class MydataServiceImpl implements MydataService{
 
         log.info("mydata service");
 
-
         Optional<List<BankAccount>> bankAccounts = bankAccountRepository.findByMydataUser_IdAndBankName(userId, bankName);
         log.info("bank accounts = {}", bankAccounts.get());
         if (bankAccounts.isPresent()) {
@@ -79,5 +81,106 @@ public class MydataServiceImpl implements MydataService{
             return Optional.empty();
         }
     }
+    @Override
+    public Optional<List<LoanDto>> getLoansByUserIdAndCompanyName(int userId, String companyName) {
+        Optional<List<Loan>> loans = loanRepository.findByMydataUser_IdAndCompanyName(userId, companyName);
+        if (loans.isPresent()) {
+            List<LoanDto> loanDtos = loans.get().stream()
+                    .map(this::convertToDto)
+                    .toList();
+            return Optional.of(loanDtos);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<List<CardDto>> getCardsByUserIdAndCompanyName(int userId, String companyName) {
+        Optional<List<Card>> cards = cardRepository.findByMydataUser_IdAndCompanyName(userId, companyName);
+        if (cards.isPresent()) {
+            List<CardDto> cardDtos = cards.get().stream()
+                    .map(this::convertToDto)
+                    .toList();
+            return Optional.of(cardDtos);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<List<PensionDto>> getPensionsByUserIdAndCompanyName(int userId, String companyName) {
+        Optional<List<Pension>> pensions = pensionRepository.findByMydataUser_IdAndCompanyName(userId, companyName);
+        if (pensions.isPresent()) {
+            List<PensionDto> pensionDtos = pensions.get().stream()
+                    .map(this::convertToDto)
+                    .toList();
+            return Optional.of(pensionDtos);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<List<SecurityAccountDto>> getSecurityAccountsByUserIdAndSecurityName(int userId, String securityName) {
+        Optional<List<SecurityAccount>> securityAccounts = securityAccountRepository.findByMydataUser_IdAndSecurityName(userId, securityName);
+        if (securityAccounts.isPresent()) {
+            List<SecurityAccountDto> securityAccountDtos = securityAccounts.get().stream()
+                    .map(this::convertToDto)
+                    .toList();
+            return Optional.of(securityAccountDtos);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private LoanDto convertToDto(Loan loan) {
+        return LoanDto.builder()
+                .companyName(loan.getCompanyName())
+                .loanType(loan.getLoanType())
+                .loanAmount(loan.getLoanAmount())
+                .interestRate(loan.getInterestRate())
+                .totalPayments(loan.getTotalPayments())
+                .accountNo(loan.getAccountNo())
+                .userId(loan.getMydataUser().getId())
+                .build();
+    }
+
+    private CardDto convertToDto(Card card) {
+        return CardDto.builder()
+                .cardNo(card.getCardNo())
+                .companyName(card.getCompanyName())
+                .cardName(card.getCardName())
+                .cardType(card.getCardType())
+                .createdAt(card.getCreatedAt())
+                .expiredAt(card.getExpiredAt())
+                .accountNo(card.getAccountNo())
+                .userId(card.getMydataUser().getId())
+                .build();
+    }
+
+    private PensionDto convertToDto(Pension pension) {
+        return PensionDto.builder()
+                .companyName(pension.getCompanyName())
+                .pensionName(pension.getPensionName())
+                .pensionType(pension.getPensionType())
+                .interestRate(pension.getInterestRate())
+                .evaluationAmount(pension.getEvaluationAmount())
+                .expirationDate(pension.getExpirationDate())
+                .accountNo(pension.getAccountNo())
+                .userId(pension.getMydataUser().getId())
+                .build();
+    }
+
+    private SecurityAccountDto convertToDto(SecurityAccount securityAccount) {
+        return SecurityAccountDto.builder()
+                .accountNo(securityAccount.getAccountNo())
+                .securityName(securityAccount.getSecurityName())
+                .accountType(securityAccount.getAccountType())
+                .balance(securityAccount.getBalance())
+                .createdAt(securityAccount.getCreatedAt())
+                .userId(securityAccount.getMydataUser().getId())
+                .build();
+    }
+
 
 }

--- a/user-service/src/main/java/com/pda/user_service/jpa/User.java
+++ b/user-service/src/main/java/com/pda/user_service/jpa/User.java
@@ -3,6 +3,7 @@ package com.pda.user_service.jpa;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -12,6 +13,7 @@ import java.util.Collection;
 import java.util.List;
 
 @Getter
+@Setter
 @Entity
 @NoArgsConstructor
 @Table(name = "users")
@@ -74,4 +76,5 @@ public class User implements UserDetails  {
     public void setInvestmentTestScore(int investmentTestScore) {
         this.investmentTestScore = investmentTestScore;
     }
+
 }


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 카드, 증권, 보험, 연금 엔티티 생성
- 사용자가 연동 요청한 금융사 정보로 mydata-service에서 데이터 요청(OpenFeign)
-  마이데이터 존재하면 asset-service에 저장
- MydataInfo 테이블에 연동한 계좌 저장 

<br/>

<br/>

## 🌱 관련 이슈 (필수)
- #2 

<br/> 
