### PR TITLE
#49 fix: 포트폴리오 서비스에서 토큰 해석 시 NoSuchElementException 에러

### DIFF
--- a/asset-service/src/main/resources/application.properties
+++ b/asset-service/src/main/resources/application.properties
@@ -4,7 +4,7 @@ feign.client.configuration.default.connect-timeout=5000
 feign.client.configuration.default.read-timeout=5000
 logging.level.org.springframework.cloud.openfeign=DEBUG
 
-spring.jpa.hibernate.ddl-auto=update
+#spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 

--- a/mydata-service/src/main/resources/application.properties
+++ b/mydata-service/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.application.name=mydata-service
 
 
 
-spring.jpa.hibernate.ddl-auto=update
+#spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- (기능에서 어떤 부분이 구현되었는지 설명해주세요)
포트폴리오 서비스에서 토큰 해석 시 user db에 존재하는 user id임에도 NoSuchElementException 에러가 발생하여 
portfolio DB 내 users 테이블 생성하여 해결하였습니다.

![image](https://github.com/hit-it-PDA/BE/assets/37354574/e0e6bd80-3966-4e5a-9ba2-2a3dc1997e23)

<br/>

## 🌱 관련 이슈 (필수)
- (관련 이슈 번호를 작성해주세요) 
- close #49 

<br/> 

## 📚 기타 (선택) 
- (그 외 참고할 만한 내용이 있다면 작성해주세요)

<br/>
