### PR TITLE
#59 chore: rabbitMQ 환경 설정 및 예제 구현 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,5 @@ out/
 .vscode/
 
 **/application-db.properties
+**/application-mq.properties
 **/env.properties

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ allprojects {
 		implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 		implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+		// RabbitMQ
+		implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
 		compileOnly 'org.projectlombok:lombok'
 		annotationProcessor 'org.projectlombok:lombok'
 		testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/portfolio-service/src/main/java/com/pda/portfolio_service/controller/PortfolioMessageController.java
+++ b/portfolio-service/src/main/java/com/pda/portfolio_service/controller/PortfolioMessageController.java
@@ -1,0 +1,30 @@
+package com.pda.portfolio_service.controller;
+
+import com.pda.utils.rabbitmq.dto.AlarmDto;
+import com.pda.utils.rabbitmq.service.MessageService;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Objects;
+
+@RestController
+@AllArgsConstructor
+@Slf4j
+public class PortfolioMessageController {
+
+    MessageService messageService;
+
+    @PostMapping(value = "/send/message")
+    public ResponseEntity<?> sendMessage(@RequestParam String serviceName, @RequestBody AlarmDto alarmDto) {
+        if (Objects.equals(serviceName, "user")) {
+            messageService.sendMessageToUserService(alarmDto);
+        }
+
+        return ResponseEntity.ok("Message sent to RabbitMQ!");
+    }
+}

--- a/user-service/src/main/java/com/pda/security/WebSecurityConfig.java
+++ b/user-service/src/main/java/com/pda/security/WebSecurityConfig.java
@@ -41,7 +41,7 @@ public class WebSecurityConfig {
                 )
                 .authorizeHttpRequests(authorizeRequests -> authorizeRequests
                         .requestMatchers("/api/assets/**", "/api/mydata/**", "/api/portfolios/**", "/error", "/api/users/signup", "/api/users/login", "/api/users/login/kakao",
-                                "/api/investment_tests/questions/**")
+                                "/api/investment_tests/questions/**", "/send/**")
                         .permitAll()
                         .anyRequest().authenticated()
                 )

--- a/user-service/src/main/java/com/pda/user_service/service/UserMessageService.java
+++ b/user-service/src/main/java/com/pda/user_service/service/UserMessageService.java
@@ -1,0 +1,39 @@
+package com.pda.user_service.service;
+
+import com.pda.user_service.jpa.User;
+import com.pda.user_service.jpa.UserRepository;
+import com.pda.utils.api_utils.CustomStringUtils;
+import com.pda.utils.exception.login.NotFoundUserException;
+import com.pda.utils.rabbitmq.dto.AlarmDto;
+import com.pda.utils.rabbitmq.service.MessageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@PropertySource("application-mq.properties")
+public class UserMessageService {
+
+    private final RabbitTemplate rabbitTemplate;
+    private final MessageService messageService;
+    private final UserRepository userRepository;
+
+    @RabbitListener(queues = "${spring.rabbitmq.queue.name}")
+    public void receiveMessage(AlarmDto alarmDto) {
+        log.info("User Queue 내의 결과 값을 반환 받습니다 ");
+        log.info("user id : " + alarmDto.getUserId());
+        log.info("relalncing id : " + alarmDto.getRebalancingId());
+        log.info("check : " + alarmDto.getCheck());
+        log.info("check : " + alarmDto.getCheck());
+        log.info("summary : " + alarmDto.getSummary());
+
+        // TODO: 알림 Repository에 올리기
+    }
+
+
+}

--- a/utils/src/main/java/com/pda/utils/rabbitmq/config/RabbitMQConfig.java
+++ b/utils/src/main/java/com/pda/utils/rabbitmq/config/RabbitMQConfig.java
@@ -1,0 +1,75 @@
+package com.pda.utils.rabbitmq.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.DefaultJackson2JavaTypeMapper;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+import java.util.HashMap;
+
+
+@PropertySource("application-mq.properties")
+@Configuration
+public class RabbitMQConfig {
+
+    @Value("${spring.rabbitmq.host}")
+    private String rabbitmqHost;
+    @Value("${spring.rabbitmq.port}")
+    private int rabbitmqPort;
+    @Value("${spring.rabbitmq.username}")
+    private String rabbitmqUsername;
+    @Value("${spring.rabbitmq.password}")
+    private String rabbitmqPassword;
+    @Value("${spring.rabbitmq.queues.userQueue}")
+    private String userQueueName;
+    @Value("${spring.rabbitmq.exchanges.userExchange}")
+    private String userExchangeName;
+    @Value("${spring.rabbitmq.routing.userRoutingKey}")
+    private String userRoutingKey;
+
+    @Bean
+    public Queue userQueue() {
+        return new Queue(userQueueName);
+    }
+    @Bean
+    public DirectExchange userExchange() {
+        return new DirectExchange(userExchangeName);
+    }
+    @Bean
+    public Binding userBinding(@Qualifier("userQueue") Queue userQueue, @Qualifier("userExchange") DirectExchange userExchange) {
+        return BindingBuilder.bind(userQueue).to(userExchange).with(userRoutingKey);
+    }
+
+    @Bean
+    public ConnectionFactory connectionFactory() {
+        CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+        connectionFactory.setHost(rabbitmqHost);
+        connectionFactory.setPort(rabbitmqPort);
+        connectionFactory.setUsername(rabbitmqUsername);
+        connectionFactory.setPassword(rabbitmqPassword);
+        return connectionFactory;
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        rabbitTemplate.setMessageConverter(jackson2JsonMessageConverter());
+        return rabbitTemplate;
+    }
+
+    @Bean
+    public MessageConverter jackson2JsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+}

--- a/utils/src/main/java/com/pda/utils/rabbitmq/dto/AlarmDto.java
+++ b/utils/src/main/java/com/pda/utils/rabbitmq/dto/AlarmDto.java
@@ -1,0 +1,24 @@
+package com.pda.utils.rabbitmq.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class AlarmDto {
+    private int userId;
+    private int rebalancingId;
+    private Boolean check;
+    private String summary;
+}

--- a/utils/src/main/java/com/pda/utils/rabbitmq/service/MessageService.java
+++ b/utils/src/main/java/com/pda/utils/rabbitmq/service/MessageService.java
@@ -1,0 +1,27 @@
+package com.pda.utils.rabbitmq.service;
+
+import com.pda.utils.rabbitmq.dto.AlarmDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class MessageService {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    @Value("${spring.rabbitmq.exchanges.userExchange}")
+    private String userExchangeName;
+
+    @Value("${spring.rabbitmq.routing.userRoutingKey}")
+    private String userRoutingKey;
+
+    public void sendMessageToUserService(AlarmDto alarmDto) {
+        log.info("Sending message to User Service: {}", alarmDto.getUserId());
+        rabbitTemplate.convertAndSend(userExchangeName, userRoutingKey, alarmDto);
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- (기능에서 어떤 부분이 구현되었는지 설명해주세요)
- rabbitMQ 환경 설정
- portfolio -> user 예제 구현 

> POST http://localhost:8084/send/message?serviceName=user
> Request Body  
```json
{
    "user_id": 1,
    "rebalancing_id" : 1,
    "check": false,
    "summary": "mq 테스트"
}
```

<br/>

## 🌱 관련 이슈 (필수)
- (관련 이슈 번호를 작성해주세요) 
- close #59

<br/> 

## 📚 기타 (선택) 
- (그 외 참고할 만한 내용이 있다면 작성해주세요)
- 현재 포트폴리오 서비스 하위에 유저 서비스 구조로 되어 있어 포트폴리오 서비스, 유저 서비스를 실행하면 유저 컨슈머가 2개가 되는 현상 발생
-> Gateway 설정, User 서비스 하위 모듈에서 제거가 필요해 보입니다.

<br/>
